### PR TITLE
Replace reset.css with normalize.css

### DIFF
--- a/static/50x.html
+++ b/static/50x.html
@@ -4,7 +4,7 @@
 <title>... Please Hold ...</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <link rel="search" type="application/opensearchdescription+xml" href="/static/opensearch.xml" title="mltshp">
-<link type="text/css" rel="stylesheet" href="/static/css/reset.css">
+<link type="text/css" rel="stylesheet" href="/static/css/normalize.css">
 <link type="text/css" rel="stylesheet" href="/static/css/fun-form.css">
 <link type="text/css" rel="stylesheet" href="/static/css/main.css">
 <link type="text/css" rel="stylesheet" href="/static/css/account.css">

--- a/static/css/account.css
+++ b/static/css/account.css
@@ -113,9 +113,9 @@
 }
 
 .sidebar .following ul {
-  padding-top: 15px;
-  padding-left: 15px;
-  padding-bottom: 15px;
+  margin: 0;
+  padding: 15px 0 15px 15px;
+  list-style: none;
   float: left;
 }
 

--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -11,6 +11,12 @@
   float: none;
 }
 
+.admin-new-users .body #new-members-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 .admin-new-users .body #new-members-list > li {
   margin-bottom: 30px;
   padding-bottom: 30px;
@@ -94,4 +100,16 @@
 
 .admin-new-users .image-medium .user-and-title > a {
     display: none;
+}
+
+.shake-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.admin-nav {
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,7 +1,9 @@
 html, body {
   font-family: Helvetica,Arial,sans-serif;
   background-color: #dbfaff;
+  color: #000;
   overflow-x: hidden;
+  margin: 0;
 }
 
 .page {
@@ -13,8 +15,29 @@ html, body {
   margin: 0 auto;
 }
 
-a, a:link {
+a {
   color: #42b4ff;
+}
+
+a:hover,
+a:focus,
+a:active {
+  color: #0088f1;
+}
+
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
 }
 
 /* Beta Alert */
@@ -186,6 +209,12 @@ a, a:link {
   border-top-right-radius: 10px;
 }
 
+.header .choose-a-shake ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 .header .choose-a-shake-bd ul.top-shakes li a {
   display: block;
   background-color: #fff;
@@ -280,9 +309,10 @@ a, a:link {
 }
 
 .header .user-nav ul {
-  padding-left: 10px;
+  margin: 0;
+  padding: 0 0 5px 10px;
+  list-style: none;
   float: left;
-  padding-bottom: 5px;
 }
 
 .header .user-nav li {
@@ -410,7 +440,9 @@ h1 {
 
 .content-find-shakes .find-shakes-navigation {
   float: left;
-  margin-left: 40px;
+  margin: 0 0 0 40px;
+  padding: 0;
+  list-style: none;
 }
 
 .content-find-shakes .find-shakes-navigation li {
@@ -561,6 +593,9 @@ h1 {
 
 .content-find-shakes .featured-shakes ul {
   float: left;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .content-find-shakes .featured-shakes li {
@@ -744,6 +779,9 @@ h1 {
 
 .content-settings .settings-navigation ul {
   float: left;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .content-settings .settings-navigation li {
@@ -889,6 +927,8 @@ h1 {
 .settings-body-connections .apps {
   width: 500px;
   margin: 30px 0;
+  padding: 0;
+  list-style: none;
 }
 
 .settings-body-connections .apps li {
@@ -953,6 +993,8 @@ h1 {
   font-size: 24px;
   color: #333;
   margin: 40px 0;
+  padding: 0;
+  list-style: none;
 }
 
 .content-upgrade li {
@@ -1078,6 +1120,9 @@ h1 {
 
 .image-content .image-interactions .save-this-shake-selector ul {
   clear: both;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .image-content .image-interactions .save-this-shake-selector a {
@@ -1276,6 +1321,12 @@ h1 {
   -webkit-border-radius: 10px;
   -moz-border-radius: 10px;
   border-radius: 10px;
+}
+
+.permalink-sidebar .in-these-shakes ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .permalink-sidebar .in-these-shakes li {
@@ -1536,6 +1587,7 @@ h1 {
   padding: 10px;
   color: #4b4b4b;
   margin: 0 10px 10px 10px;
+  list-style: none;
   -webkit-border-radius: 10px;
   -moz-border-radius: 10px;
   border-radius: 10px;
@@ -1782,7 +1834,8 @@ h1 {
 }
 
 .cool-tools-block .browser-tools  {
-  margin-top: 20px;
+  list-style: none;
+  margin: 20px 0 0;
   background-color: #f6f6f6;
   padding: 10px;
   -webkit-border-radius: 10px;
@@ -1910,6 +1963,8 @@ h1 {
   box-shadow:inset 0px 0px 10px rgba(0,0,0,.1);
   -webkit-box-shadow:inset 0px 0px 10px rgba(0,0,0,.1);
   -moz-box-shadow:inset 0px 0px 10px rgba(0,0,0,.1);
+  margin: 0;
+  list-style: none;
 }
 
 .shake-invite-member-block .shake-results li {
@@ -1981,7 +2036,9 @@ h1 {
 }
 
 .content-shake .shake-members {
+  margin: 0;
   padding: 30px;
+  list-style: none;
 }
 
 .content-shake .shake-members li {
@@ -2111,6 +2168,9 @@ h1 {
 .user-counts ul {
   float: left;
   width: 255px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .user-counts li {
@@ -2364,7 +2424,9 @@ h1 {
 }
 
 .image-content-footer .stats {
-  margin-left: 10px;
+  list-style: none;
+  margin: 0 0 0 10px;
+  padding: 0;
   color: #4b4b4b;
   float: left;
 }
@@ -2844,7 +2906,9 @@ h1 {
 }
 
 .image-medium .stats {
-  padding-top: 10px;
+  margin: 0;
+  padding: 10px 0 0;
+  list-style: none;
   color: #4b4b4b;
   clear: both;
   float: left;
@@ -3367,8 +3431,10 @@ span.previous-link {
   margin-bottom: 15px;
 }
 
-.content-conversations .conversations-nav {
-
+.content-conversations .conversations-nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 .content-conversations .conversations-nav li {
@@ -3568,21 +3634,6 @@ span.previous-link {
     margin-bottom:15px;
     margin-top:15px;
 }
-
-.content-developer ol li{
-    list-style-type:decimal;
-    margin-left:40px;
-}
-
-.content-developer strong {
-    font-weight:bold;
-}
-
-.content-developer ul li {
-    list-style-type:disc;
-    margin-left:40px;
-}
-
 
 /* Terms of Use Page */
 .terms-of-use p {
@@ -4060,7 +4111,9 @@ span.previous-link {
   clear: both;
   background-color: #dfffcb;
   width: 200px;
+  margin: 0;
   padding: 10px 0 5px 0;
+  list-style: none;
   -webkit-border-radius: 10px;
   -moz-border-radius: 10px;
   border-radius: 10px;
@@ -4207,6 +4260,8 @@ span.previous-link {
 /* Create Account */
 ul.promotions {
     margin: 10px 0;
+    padding: 0;
+    list-style: none;
 }
 ul.promotions li {
     box-sizing: border-box;

--- a/static/css/normalize.css
+++ b/static/css/normalize.css
@@ -1,0 +1,427 @@
+/*! normalize.css v6.0.0 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+   ========================================================================== */
+
+/**
+ * 1. Correct the line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in
+ *    IE on Windows Phone and in iOS.
+ */
+
+html {
+  line-height: 1.15; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/* Sections
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+article,
+aside,
+footer,
+header,
+nav,
+section {
+  display: block;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in IE.
+ */
+
+figcaption,
+figure,
+main { /* 1 */
+  display: block;
+}
+
+/**
+ * Add the correct margin in IE 8.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ */
+
+a {
+  background-color: transparent; /* 1 */
+  -webkit-text-decoration-skip: objects; /* 2 */
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57- and Firefox 39-.
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
+ */
+
+b,
+strong {
+  font-weight: inherit;
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font style in Android 4.3-.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Add the correct background and color in IE 9-.
+ */
+
+mark {
+  background-color: #ff0;
+  color: #000;
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+audio,
+video {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in iOS 4-7.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Remove the border on images inside links in IE 10-.
+ */
+
+img {
+  border-style: none;
+}
+
+/**
+ * Hide the overflow in IE.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Remove the margin in Firefox and Safari.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  margin: 0;
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input { /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+button,
+select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
+ *    controls in Android 4.
+ * 2. Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button,
+html [type="button"], /* 1 */
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * 1. Add the correct display in IE 9-.
+ * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Remove the default vertical scrollbar in IE.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10-.
+ * 2. Remove the padding in IE 10-.
+ */
+
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
+ */
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in Edge, IE, and Firefox.
+ */
+
+details, /* 1 */
+menu {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/* Scripting
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+canvas {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in IE.
+ */
+
+template {
+  display: none;
+}
+
+/* Hidden
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10-.
+ */
+
+[hidden] {
+  display: none;
+}

--- a/static/css/reset.css
+++ b/static/css/reset.css
@@ -1,7 +1,0 @@
-/*
-Copyright (c) 2010, Yahoo! Inc. All rights reserved.
-Code licensed under the BSD License:
-http://developer.yahoo.com/yui/license.html
-version: 2.8.1
-*/
-html{color:#000;background:#FFF;}body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,code,form,fieldset,legend,input,button,textarea,p,blockquote,th,td{margin:0;padding:0;}table{border-collapse:collapse;border-spacing:0;}fieldset,img{border:0;}address,caption,cite,code,dfn,em,strong,th,var,optgroup{font-style:inherit;font-weight:inherit;}del,ins{text-decoration:none;}li{list-style:none;}caption,th{text-align:left;}h1,h2,h3,h4,h5,h6{font-size:100%;font-weight:normal;}q:before,q:after{content:'';}abbr,acronym{border:0;font-variant:normal;}sup{vertical-align:baseline;}sub{vertical-align:baseline;}legend{color:#000;}input,button,textarea,select,optgroup,option{font-family:inherit;font-size:inherit;font-style:inherit;font-weight:inherit;}input,button,textarea,select{*font-size:100%;}

--- a/templates/admin/_sidebar.html
+++ b/templates/admin/_sidebar.html
@@ -1,5 +1,7 @@
 <div class="sidebar">
-  <ol>
+  <ol class="admin-nav">
+  <!-- <li><a href="/admin/interesting-stats">interesting stats</a></li> -->
+  <!-- <li><a href="/admin/waitlist">waitlist</a></li> -->
     <li><a href="/admin/create-users">create users</a></li>
     <li><a href="/admin/nsfw-users">nsfw users</a></li>
     <li><a href="/admin/new-users">new users</a></li>

--- a/templates/admin/create-users.html
+++ b/templates/admin/create-users.html
@@ -1,14 +1,26 @@
 {%extends "base.html" %}
 
+{% block title %}Create Users{% end %}
+
+{% block included_headers %}
+<link type="text/css" rel="stylesheet" href="{{ static_url("css/admin.css") }}">
+{% end %}
+
 {% block main %}
-<p>
-email address, one per line
-</p>
-<form method="POST" action="/admin/create-users">
-  {{ xsrf_form_html() }}
-  
-  <textarea cols="80" rows="15" name="emails"></textarea><br>
-  <input type="submit" value="save">
-  
-</form>
+<div class="content content-with-sidebar admin-new-users">
+  {% include "admin/_sidebar.html" %}
+
+  <div class="body">
+    <p>
+    email address, one per line
+    </p>
+    <form method="POST" action="/admin/create-users">
+      {{ xsrf_form_html() }}
+
+      <textarea cols="80" rows="15" name="emails"></textarea><br>
+      <input type="submit" value="save">
+
+    </form>
+  </div>
+</div>
 {% end %}

--- a/templates/admin/delete-user.html
+++ b/templates/admin/delete-user.html
@@ -1,13 +1,21 @@
 {%extends "base.html" %}
 
+{% block title %}Delete User{% end %}
+
+{% block included_headers %}
+<link type="text/css" rel="stylesheet" href="{{ static_url("css/admin.css") }}">
+{% end %}
+
 {% block main %}
-<p>
-delete user
-</p>
-<form method="POST" action="/admin/delete-user">
-  {{ xsrf_form_html() }}
-  User ID: <input type="text" name="user_id" value=""><br>
-  User Name: <input type="text" name="user_name" value=""><br>  
-  <input type="submit" value="delete user">
-</form>
+<div class="content content-narrow admin-new-users">
+    <p>
+    delete user
+    </p>
+    <form method="POST" action="/admin/delete-user">
+      {{ xsrf_form_html() }}
+      User ID: <input type="text" name="user_id" value=""><br>
+      User Name: <input type="text" name="user_name" value=""><br>
+      <input type="submit" value="delete user">
+    </form>
+</div>
 {% end %}

--- a/templates/admin/group-shake-list.html
+++ b/templates/admin/group-shake-list.html
@@ -1,23 +1,33 @@
 {%extends "base.html" %}
 
+{% block title %}Group Shakes{% end %}
+
+{% block included_headers %}
+<link type="text/css" rel="stylesheet" href="{{ static_url("css/admin.css") }}">
+{% end %}
+
 {% block main %}
-<div class="content content-narrow">
-  <h1>All Shakes</h1>
-  <ol>
-  {% for group_shake in group_shakes %}
-    <li>
-        <table border="0">
-          <tr>
-            <td width="80"><img src="{{group_shake.thumbnail_url()}}" width="48" height="48"></td>
-            <td width="200"><a href="/{{group_shake.name}}" target="_blank">{{group_shake.display_name()}}</a><br>
-                {{group_shake.description}}</td>
-            <td><a href="/admin/group-shake/{{group_shake.id}}">Edit Shake</a></td>
-          </tr>
-        </table>
-        <hr>
-    </li>
-  {% end %}
-  </ol>
+<div class="content content-with-sidebar admin-new-users">
+  {% include "admin/_sidebar.html" %}
+
+  <div class="body">
+    <h1>All Shakes</h1>
+    <ol class="shake-list">
+    {% for group_shake in group_shakes %}
+      <li>
+          <table border="0">
+            <tr>
+              <td width="80"><img src="{{group_shake.thumbnail_url()}}" width="48" height="48"></td>
+              <td width="200"><a href="/{{group_shake.name}}" target="_blank">{{group_shake.display_name()}}</a><br>
+                  {{group_shake.description}}</td>
+              <td><a href="/admin/group-shake/{{group_shake.id}}">Edit Shake</a></td>
+            </tr>
+          </table>
+          <hr>
+      </li>
+    {% end %}
+    </ol>
+  </div>
 </div>
 {% end %}
 

--- a/templates/admin/group-shake-recommended.html
+++ b/templates/admin/group-shake-recommended.html
@@ -1,22 +1,32 @@
 {%extends "base.html" %}
 
+{% block title %}Recommend a Group Shake{% end %}
+
+{% block included_headers %}
+<link type="text/css" rel="stylesheet" href="{{ static_url("css/admin.css") }}">
+{% end %}
+
 {% block main %}
-<div class="content content-narrow">
-  <h1>Recommend Shakes</h1>
-  <ol>
-  {% for group_shake in group_shakes %}
-    <li>
-        <table border="0">
-          <tr>
-            <td width="80"><img src="{{group_shake.thumbnail_url()}}" width="48" height="48"></td>
-            <td width="200"><a href="/{{group_shake.name}}" target="_blank">{{group_shake.display_name()}}</a><br>
-                {{group_shake.description}}</td>
-            <td><form style='display:inline;' method="post" action='/admin/recommend-group-shake/{% if group_shake.recommended %}unrecommend{% else %}recommend{% end %}'>{{ xsrf_form_html() }}<input type='submit' value='{% if group_shake.recommended %}unrecommend{% else %}recommend{% end %}'><input type='hidden' name='shake_id' value='{{group_shake.id}}'></form></td>
-          </tr>
-        </table>
-        <hr>
-    </li>
-  {% end %}
-  </ol>
+<div class="content content-with-sidebar admin-new-users">
+  {% include "admin/_sidebar.html" %}
+
+  <div class="body">
+    <h1>Recommend Shakes</h1>
+    <ol class="shake-list">
+    {% for group_shake in group_shakes %}
+      <li>
+          <table border="0">
+            <tr>
+              <td width="80"><img src="{{group_shake.thumbnail_url()}}" width="48" height="48"></td>
+              <td width="200"><a href="/{{group_shake.name}}" target="_blank">{{group_shake.display_name()}}</a><br>
+                  {{group_shake.description}}</td>
+              <td><form style='display:inline;' method="post" action='/admin/recommend-group-shake/{% if group_shake.recommended %}unrecommend{% else %}recommend{% end %}'>{{ xsrf_form_html() }}<input type='submit' value='{% if group_shake.recommended %}unrecommend{% else %}recommend{% end %}'><input type='hidden' name='shake_id' value='{{group_shake.id}}'></form></td>
+            </tr>
+          </table>
+          <hr>
+      </li>
+    {% end %}
+    </ol>
+  </div>
 </div>
 {% end %}

--- a/templates/admin/group-shake-view.html
+++ b/templates/admin/group-shake-view.html
@@ -1,7 +1,13 @@
 {%extends "base.html" %}
 
+{% block title %}Group Shake: {{shake.display_name()}}{% end %}
+
+{% block included_headers %}
+<link type="text/css" rel="stylesheet" href="{{ static_url("css/admin.css") }}">
+{% end %}
+
 {% block main %}
-<div class="content content-narrow">
+<div class="content content-narrow admin-new-users">
   <h1>{{shake.display_name()}}</h1>
 
   <img src="{{shake.thumbnail_url()}}" width="48" height="48">
@@ -10,7 +16,7 @@
   </p>
   <form method="POST" action="/admin/group-shake/{{shake.id}}">
     {{ xsrf_form_html() }}
-    
+
   <p>
     Shake Category : <select name="shake_category_id">
                         <option value="0">No Category</option>
@@ -25,14 +31,14 @@
                             <a href="/admin/group-shake/{{featured_shake.id}}">{{featured_shake.display_name()}}</a>
                           {% end %})
   </p>
-                
+
   <input type="submit" value="save this">
   </form>
   <p>
     <a href="/admin/group-shakes">&lt; Back to Shake List</a>
   </p>
-  
-  
+
+
 </div>
 {% end %}
 

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -1,10 +1,13 @@
-<ol>
-  <!-- <li><a href="/admin/interesting-stats">interesting stats</a></li> -->
-  <!-- <li><a href="/admin/waitlist">waitlist</a></li> -->
-  <li><a href="/admin/create-users">create users</a></li>
-  <li><a href="/admin/nsfw-users">nsfw users</a></li>
-  <li><a href="/admin/new-users">new users</a></li>
-  <li><a href="/admin/recommend-group-shake">recommend a group shake</a></li>
-  <li><a href="/admin/group-shakes">group shakes</a></li>
-  <li><a href="/admin/shake-categories">shake categories</a></li>
-</ol>
+{%extends "base.html" %}
+
+{% block title %}Admin{% end %}
+
+{% block included_headers %}
+<link type="text/css" rel="stylesheet" href="{{ static_url("css/admin.css") }}">
+{% end %}
+
+{% block main %}
+<div class="content content-narrow admin-new-users">
+    {% include "admin/_sidebar.html" %}
+</div>
+{% end %}

--- a/templates/admin/interesting-stats.html
+++ b/templates/admin/interesting-stats.html
@@ -1,7 +1,19 @@
 {%extends "base.html" %}
 
+{% block title %}Interesting Stats{% end %}
+
+{% block included_headers %}
+<link type="text/css" rel="stylesheet" href="{{ static_url("css/admin.css") }}">
+{% end %}
+
 {% block main %}
-<p>
-Total number of files uploaded: {{total_files}}
-</p>
+<div class="content content-with-sidebar admin-new-users">
+  {% include "admin/_sidebar.html" %}
+
+  <div class="body">
+    <p>
+    Total number of files uploaded: {{total_files}}
+    </p>
+  </div>
+</div>
 {% end %}

--- a/templates/admin/shake-categories.html
+++ b/templates/admin/shake-categories.html
@@ -1,29 +1,39 @@
 {%extends "base.html" %}
 
-{% block main %}
-<div class="content content-narrow">
-  <h1>Shake Categories</h1>
-  <p>
-    No delete yet. Sorry.
-  </p>
-  <ul>
-    {% for shake_category in shake_categories %}
-      <li>{{shake_category.name}} - {{shake_category.short_name}}</li>
-    {% end %}
-  </ul>
-  <p>
-    Save A New Category
-  </p>
-  <form method="POST" action="/admin/shake-categories">
-    {{ xsrf_form_html() }}
+{% block title %}Shake Categories{% end %}
 
-    Name: <input type="text" name="name"><br>
-    Short name: <input type="text" name="short_name" ><br>
-    <input type="submit" value="save it">
-  </form>
-  <p>
-    <a href="/admin/">&lt; Back to the Admin</a>
-  </p>
+{% block included_headers %}
+<link type="text/css" rel="stylesheet" href="{{ static_url("css/admin.css") }}">
+{% end %}
+
+{% block main %}
+<div class="content content-with-sidebar admin-new-users">
+  {% include "admin/_sidebar.html" %}
+
+  <div class="body">
+    <h1>Shake Categories</h1>
+    <p>
+      No delete yet. Sorry.
+    </p>
+    <ul>
+      {% for shake_category in shake_categories %}
+        <li>{{shake_category.name}} - {{shake_category.short_name}}</li>
+      {% end %}
+    </ul>
+    <p>
+      Save A New Category
+    </p>
+    <form method="POST" action="/admin/shake-categories">
+      {{ xsrf_form_html() }}
+
+      Name: <input type="text" name="name"><br>
+      Short name: <input type="text" name="short_name" ><br>
+      <input type="submit" value="save it">
+    </form>
+    <p>
+      <a href="/admin/">&lt; Back to the Admin</a>
+    </p>
+  </div>
 </div>
 {% end %}
 

--- a/templates/admin/waitlist.html
+++ b/templates/admin/waitlist.html
@@ -1,12 +1,22 @@
 {%extends "base.html" %}
 
+{% block title %}Waitlist{% end %}
+
+{% block included_headers %}
+<link type="text/css" rel="stylesheet" href="{{ static_url("css/admin.css") }}">
+{% end %}
+
 {% block main %}
-<div class="content content-narrow">
-  <h1>Waitlist</h1>
-  <ol>
-  {% for waiter in waiters %}
-    <li>{{waiter.created_at.strftime('%B %d')}} - {{waiter.email}}&nbsp;<form style='display:inline;' method="post" action='/admin/waitlist'>{{ xsrf_form_html() }}<input type='submit' value='invite {% if waiter.verified %}(verified){% end %}'><input type='hidden' name='waitlist_id' value='{{waiter.id}}'></form></li>
-  {% end %}
-  </ol>
+<div class="content content-with-sidebar admin-new-users">
+  {% include "admin/_sidebar.html" %}
+
+  <div class="body">
+      <h1>Waitlist</h1>
+      <ol>
+      {% for waiter in waiters %}
+        <li>{{waiter.created_at.strftime('%B %d')}} - {{waiter.email}}&nbsp;<form style='display:inline;' method="post" action='/admin/waitlist'>{{ xsrf_form_html() }}<input type='submit' value='invite {% if waiter.verified %}(verified){% end %}'><input type='hidden' name='waitlist_id' value='{{waiter.id}}'></form></li>
+      {% end %}
+      </ol>
+  </div>
 </div>
 {% end %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="search" type="application/opensearchdescription+xml" href="{{ static_url("opensearch.xml") }}" title="mltshp">
 
-    <link type="text/css" rel="stylesheet" href="{{ static_url("css/reset.css") }}">
+    <link type="text/css" rel="stylesheet" href="{{ static_url("css/normalize.css") }}">
     <link type="text/css" rel="stylesheet" href="{{ static_url("css/fun-form.css") }}">
     <link type="text/css" rel="stylesheet" href="{{ static_url("css/main.css") }}">
     <link type="text/css" rel="stylesheet" href="{{ static_url("css/account.css") }}">

--- a/templates/tools/base-sign-in.html
+++ b/templates/tools/base-sign-in.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>{% block title%}mltshp{% end %}</title>
-    <link type="text/css" rel="stylesheet" href="{{ static_url("css/reset.css") }}">
+    <link type="text/css" rel="stylesheet" href="{{ static_url("css/normalize.css") }}">
     <link type="text/css" rel="stylesheet" href="{{ static_url("css/fun-form.css") }}">
     <link type="text/css" rel="stylesheet" href="{{ static_url("css/tools.css") }}">
     {% block included_headers %}{% end %}
@@ -15,7 +15,7 @@
     <div class="tools-signin-logo">
       <img class="tools-signin-logo" src="{{ static_url("images/mlkshk-tools-logo.gif") }}">
     </div>
-    
+
     <div class="content-sign-in">
       {% block main %}
         {{content}}

--- a/templates/tools/base.html
+++ b/templates/tools/base.html
@@ -3,11 +3,11 @@
   <head>
     <title>{% block title%}mltshp{% end %}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <link type="text/css" rel="stylesheet" href="{{ static_url("css/reset.css") }}">
+    <link type="text/css" rel="stylesheet" href="{{ static_url("css/normalize.css") }}">
     <link type="text/css" rel="stylesheet" href="{{ static_url("css/fun-form.css") }}">
     <link type="text/css" rel="stylesheet" href="{{ static_url("css/tools.css") }}">
     {% block included_headers %}{% end %}
-   
+
     <script type="text/javascript" charset="utf-8">
       window.resizeTo(850,650);
       window.moveTo(screen.width/2-450,screen.height/2-300)


### PR DESCRIPTION
Reset stylesheets are no longer a best practice due to heavy-handed
effects on a site. The preferred option is to use normalize.css, which
is regularly updated and works to only change things that are different
between browsers.

This commit removes reset.css and replaces it with normalize.css.
It also updated some of the site styles to avoid any visual changes as
a result of this change. Primarily, that meant zeroing out margins on
headlines and removing margins and list styles from many unordered
lists on the site.

This change should make it much easier for other front-enders to work on
MLTSHP, because markup will behave the way it's expected to. Consider
this to be shoring up the foundation of the house before we renovate it.

This commit also affects the markup for the admin pages, just to
standardize them all to use the standard page template and admin styles,
which wasn't happening before. It's not really related to the normalize
change, except that I had to edit a couple admin pages to add classes
to lists to avoid any visual changes, and it was bugging me.