### PR TITLE
Source .deploy.env for deployment for setting enviroment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pip-log.txt
 *.swp
 env
 mounts
+.deploy.env


### PR DESCRIPTION
Cleans up deploy script logging a bit, but also sources from .deploy.env, which can be used to set `SLACK_WEBHOOK_URL` for announcing deploys to our Slack.