### PR TITLE
The right twitter name for the default "via" parameter.

### DIFF
--- a/handlers/image.py
+++ b/handlers/image.py
@@ -106,7 +106,7 @@ class ShowHandler(BaseHandler):
         if owner_twitter_account:
             owner_twitter_account = owner_twitter_account.screen_name
         else:
-            owner_twitter_account = 'mltshp'
+            owner_twitter_account = 'mltshphq'
 
         image_url = "/r/%s" % (sharedfile.share_key)
         if options.debug:


### PR DESCRIPTION
Small change to use "mltshphq" as the "via" Twitter handle when sharing posts to Twitter from someone without an associated Twitter account.