### PR TITLE
Schema migration should happen via the CMD.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,6 @@ COPY setup/production/nginx.conf /etc/nginx/nginx.conf
 ADD . /srv/mltshp.com/mltshp
 WORKDIR /srv/mltshp.com/mltshp
 RUN pip install -r requirements.txt
-RUN time python migrate.py
 
 EXPOSE 80
-CMD ["/usr/bin/supervisord"]
+CMD ["python migrate.py && /usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ WORKDIR /srv/mltshp.com/mltshp
 RUN pip install -r requirements.txt
 
 EXPOSE 80
-CMD ["python migrate.py && /usr/bin/supervisord"]
+CMD ["/bin/sh", "-c", "python migrate.py && /usr/bin/supervisord"]


### PR DESCRIPTION
Shouldn't have used `RUN` to execute the migration since that isn't part of the build.