### PR TITLE
Removing automated schema migration command.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,6 @@ COPY setup/production/nginx.conf /etc/nginx/nginx.conf
 ADD . /srv/mltshp.com/mltshp
 WORKDIR /srv/mltshp.com/mltshp
 RUN pip install -r requirements.txt
-RUN time python migrate.py
 
 EXPOSE 80
 CMD ["/usr/bin/supervisord"]

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ The directory structure looks like this:
             (mysql data files)
 
 
+## Database Migrations
+
+Occassionally, a database migration will need to be performed to
+bring an older database schema up to date. This will be necessary
+if you have a MySQL database you use locally for development and
+testing and keep it versus using the `destroy` and `init-dev`
+commands to make a new one. To update your database, just do this:
+
+    $ make shell
+    docker-shell$ cd /srv/mltshp.com/mltshp; python migrate.py
+
+That should do it.
+
+
 ## Tests
 
 With your copy of MLTSHP running, you may want to run unit tests. Some


### PR DESCRIPTION
Schema migration should be a little more manual, I suppose. Trying to do it via the Dockerfile led to a race condition when running the build locally with other docker images starting up more slowly that the web app. For production, we should handle each migration with care, particularly for situations where it might involve significant downtime (~ >= 5 minutes).