### PR TITLE
Wrap Long Strings, Don't Break Words

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2947,7 +2947,7 @@ iframe {
 }
 
 .image-content .the-description {
-  word-break: break-all;
+  word-break: break-word;
   word-wrap: break-word;
   overflow-wrap: break-word;
 }
@@ -4323,7 +4323,7 @@ span.previous-link {
   top: 0;
   left: 30px;
   right: 30px;
-  max-width: 520px;
+  max-width: 560px;
   margin: 0 auto;
   padding: 15px;
   border-bottom-right-radius: 10px;
@@ -4351,6 +4351,7 @@ span.previous-link {
 
 .new-post-panel--inner > * {
   flex: 1 1 0;
+  min-width: 0;
 }
 
 .new-post-panel .email-unverified h2 {
@@ -4371,6 +4372,7 @@ span.previous-link {
   padding-top: 15px;
   border-bottom: 1px dashed #e0e0e0;
   padding-bottom: 15px;
+  padding-right: 25px;
 }
 
 @media screen and (min-width: 768px) {
@@ -4461,13 +4463,14 @@ span.previous-link {
 }
 
 .new-post-panel .shake-selector h3 a span {
-  display: inline-block;
 }
 
 .new-post-panel .shake-selector h3 a span.green {
   color: #0caf8b;
   padding-right: 25px;
   background: #fff url('/static/images/shake-selector-carrot.gif') 100% 3px no-repeat;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .new-post-panel .shake-selector h3 a:hover span.green {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2565,6 +2565,7 @@ iframe {
 
 .user-follow .icon {
   margin-right: 10px;
+  flex: none;
 }
 
 
@@ -2572,6 +2573,8 @@ iframe {
   font-size: 14px;
   color: #333;
   margin-bottom: 5px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .user-follow h4 a {
@@ -2619,10 +2622,11 @@ iframe {
 
 .user-follow-extended .icon {
   margin-right: 10px;
+  float: left;
 }
 
 .user-follow-extended {
-  clear: left;
+  display: block;
   margin: 20px 5px;
 }
 
@@ -2655,6 +2659,8 @@ iframe {
   color: #333;
   margin-bottom: 10px;
   white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .user-follow-extended .website {

--- a/templates/uimodules/shake-follow.html
+++ b/templates/uimodules/shake-follow.html
@@ -3,7 +3,7 @@
   <a class="icon" href="{{shake.path()}}"><img src="{{shake.thumbnail_url()}}" width="{{avatar_size}}" height="{{avatar_size}}"></a>
     <div class="follow">
       <div class="details">
-        <h4><a class="icon" href="{{shake.path()}}">{{ escape(shake.display_name()) }}</a> {% if follow_user and follow_user.is_plus() %}<a href="/account/membership" title="upgraded their account!"><img src="{{ static_url("images/icon_plus.gif") }}" width="12" height="12" border="0" valign="center"></a>{% end %}</h4>
+        <h4><a href="{{shake.path()}}">{{ escape(shake.display_name()) }}</a> {% if follow_user and follow_user.is_plus() %}<a href="/account/membership" title="upgraded their account!"><img src="{{ static_url("images/icon_plus.gif") }}" width="12" height="12" border="0" valign="center"></a>{% end %}</h4>
         {% if follow_user %}
           <p class="about">{{escape(follow_user.about)}}</p>
           <p class="website">{{linkify(follow_user.website, True, extra_params='rel="nofollow" target="_blank"')}}</p>


### PR DESCRIPTION
This commit fixes an earlier change that prevented long strings of text
from breaking the layout, but was too aggressive about when to break
words. Now words will only be broken when absolutely necessary.

Also, this commit ensures that if the user has any very long strings of text
in their profile, it won't break the layout on any pages.

fixes #128
fixes #127