### PR TITLE
Reap counts from fileview table to update sharedfile counts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get -y update && apt-get install -y \
     libjpeg-dev \
     libcurl4-openssl-dev \
     curl \
+    run-one \
     wget \
     vim \
     libpcre3 \
@@ -74,6 +75,7 @@ COPY setup/production/nginx.conf /etc/nginx/nginx.conf
 ADD . /srv/mltshp.com/mltshp
 WORKDIR /srv/mltshp.com/mltshp
 RUN pip install -r requirements.txt
+RUN crontab -u ubuntu setup/production/mltshp-web--crontab
 
 EXPOSE 80
 CMD ["/usr/bin/supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV PYTHONUNBUFFERED 1
 
 RUN apt-get -y update && apt-get install -y \
     supervisor \
+    cron \
     libmysqlclient-dev \
     mysql-client \
     python-dev \

--- a/handlers/image.py
+++ b/handlers/image.py
@@ -223,8 +223,9 @@ class ShowRawHandler(BaseHandler):
         else:
             user_id = None
 
-        # count view
-        sharedfile.add_view(user_id)
+        # count views, but not for the owner of the file
+        if sharedfile.user_id != user_id:
+            sharedfile.add_view(user_id)
 
         # determine if we are to serve via CDN or direct from S3:
         if self.request.host == ("s.%s" % options.app_host) and options.use_cdn:

--- a/mltshpoptions.py
+++ b/mltshpoptions.py
@@ -37,6 +37,7 @@ define('uploaded_files', metavar='PATH', help="Path on disk where uploaded files
 define('use_workers', type=bool, default=True, help="Use asynchronous Celery workers")
 define('debug_workers', type=bool, default=False, help="Wait for asynchronous workers to complete (for testing)")
 define('use_cdn', type=bool, default=False, help="Enable if s.mltshp.com should redirect to mltshp-cdn.com for images")
+define('server_id', help='A name for this server instance (unique per server)')
 
 # APIs
 define('aws_key', metavar="KEY", help="Amazon API key for S3 & Payments")

--- a/models/fileview.py
+++ b/models/fileview.py
@@ -5,7 +5,7 @@ from tornado.options import options
 class Fileview(Model):
     user_id = Property()
     sharedfile_id = Property()
-    created_at  = Property()
+    created_at = Property()
 
     def save(self, *args, **kwargs):
         if options.readonly:
@@ -17,18 +17,17 @@ class Fileview(Model):
     @classmethod
     def last(cls):
         return cls.get("1 order by id desc limit 1")
-    
+
     @classmethod
-    def sharedfile_ids(cls, after_id=None):
+    def sharedfile_ids(cls, before_id=None):
         """
         Return sharedfile_ids that have had views logged to them.
-        
-        Limit results to fileview's > passed in after_id.
+
+        Limit results to fileview's < passed in before_id.
         """
-        sql = "select sharedfile_id from fileview "
-        if after_id:
-            sql = sql + " where id > %s" % int(after_id)
-        sql += " group by sharedfile_id"
+        sql = "select distinct sharedfile_id from fileview "
+        if before_id:
+            sql = sql + " where id < %s" % int(before_id)
         return [result['sharedfile_id'] for result in cls.query(sql)]
 
 

--- a/models/sharedfile.py
+++ b/models/sharedfile.py
@@ -444,13 +444,14 @@ class Sharedfile(ModelQueryCache, Model):
             self.created_at = datetime.utcnow()
         self.updated_at = datetime.utcnow()
 
-    def update_view_count(self):
+    def increment_view_count(self, amount):
         """
         Update view_count field for current sharedfile.
         """
-        self.update_attribute('view_count', self.calculate_view_count())
+        view_count = self.view_count or 0
+        self.update_attribute('view_count', view_count + amount)
 
-    def calculate_view_count(self):
+    def calculate_view_count(self, last_fileview=0):
         """
         Calculate count of all views for the sharedfile.
         """

--- a/models/user.py
+++ b/models/user.py
@@ -419,7 +419,7 @@ hello@mltshp.com
         """
         Returns the file like, save, and view counts
         """
-        counts = sharedfile.Sharedfile.query("SELECT sum(like_count) as likes, sum(save_count) as saves, sum(view_count) as views from sharedfile where user_id = %s", self.id)
+        counts = sharedfile.Sharedfile.query("SELECT sum(like_count) as likes, sum(save_count) as saves, sum(view_count) as views from sharedfile where user_id = %s AND deleted=0", self.id)
         counts = counts[0]
         for key, value in counts.items():
             if not value:

--- a/runner.py
+++ b/runner.py
@@ -54,8 +54,14 @@ def main(opts, args):
     script_path = args[0]
     if not script_path.endswith('.py'):
         sys.exit("You can only reference python scripts that end with a .py extension.")
-    
+
     mltshpoptions.parse_dictionary(getattr(settings, opts.settings))
+
+    # if a server argument was specified and doesn't match with the
+    # server_id configured for settings, then exit silently
+    # without running
+    if opts.server_id and opts.server_id != options.server_id:
+        exit(0)
 
     lib.flyingcow.register_connection(host=options.database_host,
         name=options.database_name, user=options.database_user,
@@ -72,4 +78,6 @@ if __name__ == '__main__':
     parser.add_option("-s", "--settings", dest="settings",
                     help="name of the settings dict inside the settings file used to bootstrap environment", 
                     metavar="PATH", default='settings')
+    parser.add_option("--server_id", dest="server_id",
+                    help="name of the server to scope for this script")
     main(*parser.parse_args())

--- a/setup/production/mltshp-web--crontab
+++ b/setup/production/mltshp-web--crontab
@@ -1,0 +1,4 @@
+# Crontab jobs for MLTSHP web server
+# Run calculate web views, but only on our primary web server, so we don't
+# have to worry about two instances trying to consume view counts at the same time
+0,5,10,15,20,25,30,35,40,45,50,55 * * * * cd /srv/mltshp.com/mltshp; run-one timeout 290s python runner.py --server_id mltshp-web-1 scripts/calculate-views.py

--- a/test/FileTests.py
+++ b/test/FileTests.py
@@ -113,7 +113,7 @@ class FileViewTests(BaseAsyncTestCase):
 
         for i in range(0,10):
             if i % 2 == 0:
-                request = HTTPRequest(self.get_url('/r/1'), 'GET', {"Cookie":"sid=%s" % (self.sid)})
+                request = HTTPRequest(self.get_url('/r/1'), 'GET', {"Cookie":"sid=%s" % (self.sid2)})
             else:
                 request = HTTPRequest(self.get_url('/r/1'), 'GET')
             self.http_client.fetch(request, self.stop)
@@ -134,7 +134,7 @@ class FileViewTests(BaseAsyncTestCase):
 
         for i in range(0,10):
             if i % 2 == 0:
-                request = HTTPRequest(self.get_url('/r/1.jpg'), 'GET', {"Cookie":"sid=%s" % (self.sid)})
+                request = HTTPRequest(self.get_url('/r/1.jpg'), 'GET', {"Cookie":"sid=%s" % (self.sid2)})
             else:
                 request = HTTPRequest(self.get_url('/r/1.jpg'), 'GET')
             self.http_client.fetch(request, self.stop)

--- a/test/SiteFunctionTests.py
+++ b/test/SiteFunctionTests.py
@@ -89,7 +89,7 @@ class FileViewTests(BaseAsyncTestCase):
             if i % 2 == 0:
                 # views by owner aren't counted
                 request = HTTPRequest(self.get_url('/r/1'), 'GET',
-                    {"Cookie":"sid=%s" % (self.sid)})
+                    {"Cookie":"sid=%s" % (self.sid2)})
             else:
                 # views by non-owner are counted
                 request = HTTPRequest(self.get_url('/r/1'), 'GET')

--- a/test/scripts/calculate_views_tests.py
+++ b/test/scripts/calculate_views_tests.py
@@ -14,7 +14,7 @@ class CalculateViewsTests(BaseTestCase):
         When the script runs for the first time, it should calculate
         the view_count for all sharedfiles, store the results in the
         script_log results table.
-        
+
         The second time it run, it should use the previous run to only
         calculate views for files that have had views since last time
         the script ran.
@@ -23,7 +23,7 @@ class CalculateViewsTests(BaseTestCase):
         sharedfile = test.factories.sharedfile(user)
         sharedfile2 = test.factories.sharedfile(user)
         sharedfile3 = test.factories.sharedfile(user)
-        
+
         sharedfile.add_view()
         sharedfile.add_view()
         sharedfile2.add_view()
@@ -34,15 +34,13 @@ class CalculateViewsTests(BaseTestCase):
         runner.run('scripts/calculate-views.py')
         self.assertEqual(2, sharedfile.get("id = %s", sharedfile.id).view_count)
         self.assertEqual(3, sharedfile2.get("id = %s", sharedfile2.id).view_count)
-        
+
         script_log = ScriptLog.last_successful('calculate-views')
         results = json.loads(script_log.result)
         self.assertEqual(2, results['updated_sharedfiles'])
-        self.assertEqual(Fileview.last().id, results['last_fileview_id'])
-        
+
         sharedfile3.add_view()
         runner.run('scripts/calculate-views.py')
         script_log = ScriptLog.last_successful('calculate-views')
-        results = json.loads(script_log.result)        
+        results = json.loads(script_log.result)
         self.assertEqual(1, results['updated_sharedfiles'])
-        self.assertEqual(Fileview.last().id, results['last_fileview_id'])

--- a/test/unit/fileview_tests.py
+++ b/test/unit/fileview_tests.py
@@ -14,23 +14,29 @@ class FileviewTests(BaseTestCase):
         sharedfile = test.factories.sharedfile(user)
         sharedfile2 = test.factories.sharedfile(user)
         sharedfile3 = test.factories.sharedfile(user)
-        
+
         sharedfile.add_view()
         sharedfile.add_view()
         sharedfile.add_view()
         self.assertEqual(1, len(Fileview.sharedfile_ids()))
         self.assertEqual(sharedfile.id, Fileview.sharedfile_ids()[0])
-        
+
         sharedfile2.add_view()
         sharedfile2.add_view()
         sharedfile2.add_view()
         self.assertEqual(2, len(Fileview.sharedfile_ids()))
-        
+
         last_id = Fileview.last().id
-        self.assertEqual(0, len(Fileview.sharedfile_ids(last_id)))
+        self.assertEqual(2, len(Fileview.sharedfile_ids(last_id+1)))
+
         sharedfile3.add_view()
-        self.assertEqual(1, len(Fileview.sharedfile_ids(last_id)))
-        self.assertEqual(sharedfile3.id, Fileview.sharedfile_ids(last_id)[0])
+        # still just "2", since we're selecting sharedfile ids
+        # that are less than last_id+1
+        self.assertEqual(2, len(Fileview.sharedfile_ids(last_id+1)))
+
+        # last sharedfile id returned before last_id should be sharedfile2
+        last_id = Fileview.last().id
+        self.assertEqual(sharedfile2.id, Fileview.sharedfile_ids(last_id)[-1])
 
 
     def test_last(self):


### PR DESCRIPTION
Without this change, the fileview table grows indefinitely and consumes all free
disk space. Installs cron job for running calculate-views script, scheduled to
update every 5 minutes.

fixes #51 