### PR TITLE
Even More Long String Fixes

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1832,31 +1832,32 @@ iframe {
 .sidebar-stats-content .user-action {
   clear: both;
   margin-bottom: 5px;
-  float: left;
+  display: flex;
 }
 
 .sidebar-stats-content .icon {
   width: 20px;
   height: 20px;
   display: block;
-  float: left;
   margin-right: 5px;
 }
 
 .sidebar-stats-content .name {
-  float: left;
   display: block;
   padding-top: 5px;
+  word-break: break-word;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .sidebar-stats-content .date {
-  float: left;
   padding-top: 7px;
   color: #7f7f7f;
   font-weight: normal;
-  font-size: 12px;
+  font-size: smaller;
   margin-left: 10px;
   display: block;
+  white-space: nowrap;
 }
 
 
@@ -2759,6 +2760,8 @@ iframe {
   font-weight: bold;
   padding-bottom: 10px;
   padding-left: 15px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .other-shakes {
@@ -4198,26 +4201,33 @@ span.previous-link {
   border-bottom: 1px dotted #e0e0e0;
 }
 
+@media screen and (min-width: 768px) {
+    .conversation {
+        display: flex;
+    }
+}
+
 .conversation .thumb {
+  flex: none;
   width: 100px;
-  float: left;
   margin-left: 30px;
 }
 
 .conversation .details-wrapper {
-  width: 465px;
-  float: left;
+  flex: 1;
   margin-left: 10px;
+  margin-right: 10px;
+  min-width: 0;
 }
 
 .conversation .sharedfile-title {
   font-size: 30px;
   font-weight: bold;
   color: #333;
-  float: left;
-  width: 445px;
   overflow: hidden;
   margin-bottom: 10px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .conversation .sharedfile-description {
@@ -4225,34 +4235,32 @@ span.previous-link {
   font-size: 14px;
   line-height: 1.3;
   overflow: hidden;
-  width: 445px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .conversation .image-comments {
   padding-left: 0;
-  width: 465px;
 }
 
 .conversation .image-comments .body {
-  width: 385px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .conversation .image-comments .comment {
-  width: 465px;
 }
 
 .conversation .image-comments .meta {
-  width: 385px;
 }
 
 .conversation .conversation-meta {
-  clear: both;
   margin-bottom: 35px;
-  float: left;
+  margin-top: 20px;
+  display: flex;
 }
 
 .conversation .post-a-comment {
-  float: left;
   display: block;
   -webkit-border-radius: 10px;
   -moz-border-radius: 10px;
@@ -4266,7 +4274,6 @@ span.previous-link {
 }
 
 .conversation .mute-this-conversation {
-  float: left;
   display: block;
   color: #00adff;
   text-decoration: none;
@@ -4278,6 +4285,11 @@ span.previous-link {
   display: none;
 }
 
+.user-name {
+    word-break: break-word;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
 
 /*----------------------------------------------
   Area: API

--- a/templates/account/confirm.html
+++ b/templates/account/confirm.html
@@ -5,7 +5,7 @@
 {% block main %}
 
   <div class="content content-narrow">
-    <h1>Hello, {{current_user['name']}}!</h1>
+    <h1>Hello, <span class="user-name">{{current_user['name']}}</span>!</h1>
 
     {% if promotion %}
     <p>Thanks for joining MLTSHP through {{ escape(promotion.name) }}!</p>

--- a/templates/account/settings-connections.html
+++ b/templates/account/settings-connections.html
@@ -23,7 +23,7 @@
       <ul id="apps" class="apps">
       {% for app in apps %}
         <li>
-          <h4><span class="title">{{escape(app.get_title())}}</span> <span class="by">by <a href="/user/{{app.user().name}}">{{app.user().name}}</a></span></h4>
+          <h4><span class="title">{{escape(app.get_title())}}</span> <span class="by">by <a class="user-name" href="/user/{{app.user().name}}">{{app.user().name}}</a></span></h4>
           <p>{{escape(app.get_description())}}</p>
           <p>
             <a class="disconnect" href="">Disconnect.</a>

--- a/templates/conversations/index.html
+++ b/templates/conversations/index.html
@@ -35,7 +35,7 @@
                     </a>
                   </div>
                   <div class="body">
-                    <div class="meta"><a href="/user/{{comment.user().name}}">{{comment.user().name}}</a> <span class="created-at">{{comment.pretty_created_at()}}</span></div>
+                    <div class="meta"><a href="/user/{{comment.user().name}}" class="user-name">{{comment.user().name}}</a> <span class="created-at">{{comment.pretty_created_at()}}</span></div>
                     {{comment.body_formatted()}}
                   </div>
                   <div class="clear"><!-- --></div>

--- a/templates/conversations/mentions.html
+++ b/templates/conversations/mentions.html
@@ -28,7 +28,7 @@
                   </a>
                 </div>
                 <div class="body">
-                  <div class="meta"><a href="/user/{{mention['comment'].user().name}}">{{mention['comment'].user().name}}</a> <span class="created-at">{{mention['comment'].pretty_created_at()}}</span></div>
+                  <div class="meta"><a class="user-name" href="/user/{{mention['comment'].user().name}}">{{mention['comment'].user().name}}</a> <span class="created-at">{{mention['comment'].pretty_created_at()}}</span></div>
                   {{mention['comment'].body_formatted()}}
                   <div class="where-from">Posted on "<a href="/p/{{mention['sharedfile'].share_key}}">{{mention['sharedfile'].get_title()}}</a>"</div>
                 </div>

--- a/templates/image/quick-comments.html
+++ b/templates/image/quick-comments.html
@@ -8,7 +8,7 @@
     <div class="comment-body">
       {% set commenting_user = comment.user() %}
       <div class="meta">
-        <a class="username link--primary" href="/user/{{commenting_user.name}}">{{commenting_user.name}}</a>
+        <a class="user-name username link--primary" href="/user/{{commenting_user.name}}">{{commenting_user.name}}</a>
         {% if commenting_user.is_plus() %}
           <a class="pro-badge" href="/account/membership">
             <img alt="pro" src="{{ static_url("images/icon_plus.svg") }}" width="12" height="12" border="0" valign="center">

--- a/templates/image/show.html
+++ b/templates/image/show.html
@@ -163,7 +163,7 @@
           <div class="body">
             {% set commenting_user = comment.user() %}
             <div class="meta">
-              <a class="username link--primary" href="/user/{{commenting_user.name}}">{{commenting_user.name}}</a>
+              <a class="user-name username link--primary" href="/user/{{commenting_user.name}}">{{commenting_user.name}}</a>
               {% if commenting_user.is_plus() %}
                 <a class="pro-badge" href="/account/membership" title="upgrade your account!">
                   <img src="{{ static_url("images/icon_plus.svg") }}" width="12" height="12" border="0" valign="center" alt="pro">

--- a/templates/uimodules/image.html
+++ b/templates/uimodules/image.html
@@ -137,7 +137,7 @@
       <a href="/user/{{original_user.name}}">
         <img class="avatar--img" valign="bottom" width="20" height="20" src="{{original_user.profile_image_url()}}" alt="">
       </a>
-      <a href="/user/{{original_user.name}}">{{ original_user.name }}</a></div>
+      <a class="user-name" href="/user/{{original_user.name}}">{{ original_user.name }}</a></div>
     {% end %}
 
     {% if list_view %}

--- a/test/functional/voucher_tests.py
+++ b/test/functional/voucher_tests.py
@@ -87,7 +87,8 @@ class VoucherTests(test.base.BaseAsyncTestCase):
         self.post_url("/create-account", arguments=arguments)
         self.sign_in(arguments["name"], arguments["password"])
         response = self.fetch_url("/confirm-account")
-        self.assertTrue(response.body.find("Hello, %s!" % arguments["name"]) > -1)
+        self.assertTrue(response.body.find(
+            "Hello, <span class=\"user-name\">%s</span>!" % arguments["name"]) > -1)
         response = self.fetch_url("/account/settings")
         self.assertTrue(response.body.find("5 Years") > -1)
 


### PR DESCRIPTION
This commit fixes some additional spots where long strings could break
the site layout:

* image title & description on conversation page
* comments & user name on conversation page
* username on confirm account page
* username on permalink likes tab
* username in comments

fixes #214
fixes #228