### PR TITLE
Fix Some Layout Bugs

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1537,6 +1537,7 @@ iframe {
       grid-gap: 30px;
       grid-template-columns: 1fr 330px;
       grid-template-areas: "title title" "image sidebar" "comments sidebar" "post-comment sidebar";
+      grid-template-rows: repeat(3, min-content) 1fr;
     }
 
     .content-permalink > * {
@@ -4566,9 +4567,17 @@ span.previous-link {
   color: #333;
   font-size: 14px;
   line-height: 18px;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
+}
+
+.shake-details .description .content {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+.shake-details .description .placeholder {
+    color: #999;
+    font-style: italic;
 }
 
 .shake-details .shake-edit-description-input {

--- a/templates/shakes/_sidebar.html
+++ b/templates/shakes/_sidebar.html
@@ -41,9 +41,9 @@
     <div class="shake-details">
       <p class="description shake-edit-description">
         {% if shake.description %}
-          {{escape(shake.description)}}
+          <span class="content">{{escape(shake.description)}}</span>
         {% else %}
-          <span class="click-to-edit">Click to edit description</span>
+          <span class="placeholder">Click to edit description</span>
         {% end %}
       </p>
       <form action="/shake/{{shake.name}}/quick-details" class="shake-edit-description-form">


### PR DESCRIPTION
1) Fix a layout bug affecting the grid layout for the permalink page,
where it was trying to space the body content out to match the height
of the sidebar. Now the page content will be no taller than it should
be and the final cell in the grid will expand to match the height of
the sidebar if it's taller.

2) Fix a bug where the whitespace in the markup for the shake
description was adding whitespace in the layout because it was set to
white-space:pre-wrap to preserve the users' linebreaks.

fixes #205
fixes #221