### PR TITLE
Prevent Long Strings from Breaking Admin Pages

### DIFF
--- a/static/css/admin.css
+++ b/static/css/admin.css
@@ -15,9 +15,10 @@
 }
 
 .admin-new-users .body #new-members-list {
-  margin: 0;
-  padding: 0;
+  margin: 30px 0 0;
+  padding: 30px 0 0;
   list-style: none;
+  border-top: 1px dashed #e0e0e0;
 }
 
 .admin-new-users .body #new-members-list > li {
@@ -36,6 +37,9 @@
   font-size: 18px;
   font-weight: bold;
   padding-bottom: 5px;
+  word-break: break-word;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .admin-new-users .body #new-members-list > li h4 a {
@@ -50,6 +54,9 @@
   color: #333;
   font-size: 14px;
   line-height: 1.3;
+  word-break: break-word;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .admin-new-users .body #new-members-list > li p a {
@@ -83,14 +90,12 @@
 }
 
 .admin-new-users .image-medium {
-    width: 100%;
     margin-left: 60px;
     padding-top: 10px;
     padding-bottom: 0;
 }
 
 .admin-new-users .image-medium .user-and-title .title {
-    width: 500px;
 }
 
 .admin-new-users .image-medium .user-and-title > a {
@@ -98,9 +103,31 @@
 }
 
 .shake-list {
-  margin: 0;
-  padding: 0;
+  margin: 30px 0 0;
+  padding: 30px 0 0;
   list-style: none;
+  border-top: 1px dashed #e0e0e0;
+}
+
+.shake-list--shake {
+    margin-bottom: 30px;
+    padding-bottom: 30px;
+    clear: both;
+    border-bottom: 1px dashed #e0e0e0;
+}
+
+.shake-list--thumb {
+    float: left;
+    margin-right: 1em;
+}
+
+.shake-view-title,
+.shake-view-description,
+.shake-view-featured,
+.shake-list--description {
+    word-break: break-word;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
 }
 
 .admin-nav {

--- a/templates/admin/create-users.html
+++ b/templates/admin/create-users.html
@@ -8,19 +8,25 @@
 
 {% block main %}
 <div class="content content-with-sidebar admin-new-users">
-  {% include "admin/_sidebar.html" %}
+    {% include "admin/_sidebar.html" %}
 
-  <div class="body">
-    <p>
-    email address, one per line
-    </p>
-    <form method="POST" action="/admin/create-users">
-      {{ xsrf_form_html() }}
-
-      <textarea cols="80" rows="15" name="emails"></textarea><br>
-      <input type="submit" value="save">
-
-    </form>
-  </div>
+    <div class="body">
+        <h1>Create Users</h1>
+        <form class="fun-form fun-form-stacked" method="POST" action="/admin/create-users">
+            {{ xsrf_form_html() }}
+            <div class="field">
+                <label>Email Addresses:</label>
+                <div class="field-input">
+                    <textarea cols="80" rows="15" name="emails"></textarea>
+                </div>
+                <div class="field-help">
+                    one per line
+                </div>
+            </div>
+            <div class="field field-submit">
+                <button class="btn btn-primary btn-shadow" type="submit">Create Users</button>
+            </div>
+        </form>
+    </div>
 </div>
 {% end %}

--- a/templates/admin/group-shake-list.html
+++ b/templates/admin/group-shake-list.html
@@ -14,17 +14,18 @@
     <h1>All Shakes</h1>
     <ol class="shake-list">
     {% for group_shake in group_shakes %}
-      <li>
-          <table border="0">
-            <tr>
-              <td width="80"><img src="{{group_shake.thumbnail_url()}}" width="48" height="48"></td>
-              <td width="200"><a href="/{{group_shake.name}}" target="_blank">{{group_shake.display_name()}}</a><br>
-                  {{group_shake.description}}</td>
-              <td><a href="/admin/group-shake/{{group_shake.id}}">Edit Shake</a></td>
-            </tr>
-          </table>
-          <hr>
-      </li>
+        <li class="shake-list--shake">
+            <div class="shake-list--thumb">
+                <img src="{{group_shake.thumbnail_url()}}" width="48" height="48">
+            </div>
+            <div class="shake-list--description">
+                <a href="/{{group_shake.name}}" target="_blank">{{group_shake.display_name()}}</a>
+                <p>{{group_shake.description}}</p>
+            </div>
+            <div class="shake-list--recommend">
+                <a class="btn btn-small btn-pastel btn-primary" href="/admin/group-shake/{{group_shake.id}}">edit</a>
+            </div>
+        </li>
     {% end %}
     </ol>
   </div>

--- a/templates/admin/group-shake-recommended.html
+++ b/templates/admin/group-shake-recommended.html
@@ -14,16 +14,21 @@
     <h1>Recommend Shakes</h1>
     <ol class="shake-list">
     {% for group_shake in group_shakes %}
-      <li>
-          <table border="0">
-            <tr>
-              <td width="80"><img src="{{group_shake.thumbnail_url()}}" width="48" height="48"></td>
-              <td width="200"><a href="/{{group_shake.name}}" target="_blank">{{group_shake.display_name()}}</a><br>
-                  {{group_shake.description}}</td>
-              <td><form style='display:inline;' method="post" action='/admin/recommend-group-shake/{% if group_shake.recommended %}unrecommend{% else %}recommend{% end %}'>{{ xsrf_form_html() }}<input type='submit' value='{% if group_shake.recommended %}unrecommend{% else %}recommend{% end %}'><input type='hidden' name='shake_id' value='{{group_shake.id}}'></form></td>
-            </tr>
-          </table>
-          <hr>
+      <li class="shake-list--shake">
+          <div class="shake-list--thumb">
+              <img src="{{group_shake.thumbnail_url()}}" width="48" height="48">
+          </div>
+          <div class="shake-list--description">
+              <a href="/{{group_shake.name}}" target="_blank">{{group_shake.display_name()}}</a>
+              <p>{{group_shake.description}}</p>
+          </div>
+          <div class="shake-list--recommend">
+              <form style='display:inline;' method="post" action='/admin/recommend-group-shake/{% if group_shake.recommended %}unrecommend{% else %}recommend{% end %}'>
+                  {{ xsrf_form_html() }}
+                  <input class="btn btn-small btn-pastel btn-primary" type='submit' value='{% if group_shake.recommended %}unrecommend{% else %}recommend{% end %}'>
+                  <input type='hidden' name='shake_id' value='{{group_shake.id}}'>
+              </form>
+          </div>
       </li>
     {% end %}
     </ol>

--- a/templates/admin/group-shake-view.html
+++ b/templates/admin/group-shake-view.html
@@ -8,10 +8,10 @@
 
 {% block main %}
 <div class="content content-narrow admin-new-users">
-  <h1>{{shake.display_name()}}</h1>
+  <h1 class="shake-view-title">{{shake.display_name()}}</h1>
 
   <img src="{{shake.thumbnail_url()}}" width="48" height="48">
-  <p>
+  <p class="shake-view-description">
     {{shake.description}}
   </p>
   <form method="POST" action="/admin/group-shake/{{shake.id}}">
@@ -28,14 +28,14 @@
   <p>
     Featured? <input type="checkbox" name="featured" value="1" {% if shake.featured %}CHECKED{%end%} >
     Currently featured: ({% for featured_shake in featured_shakes %}
-                            <a href="/admin/group-shake/{{featured_shake.id}}">{{featured_shake.display_name()}}</a>
+                            <a class="shake-view-featured" href="/admin/group-shake/{{featured_shake.id}}">{{featured_shake.display_name()}}</a>
                           {% end %})
   </p>
 
-  <input type="submit" value="save this">
+  <input class="btn btn-primary btn-shadow" type="submit" value="save this">
   </form>
   <p>
-    <a href="/admin/group-shakes">&lt; Back to Shake List</a>
+    <a class="btn btn-pastel btn-secondary" href="/admin/group-shakes">&lt; Back to Shake List</a>
   </p>
 
 

--- a/templates/admin/new-users.html
+++ b/templates/admin/new-users.html
@@ -34,11 +34,11 @@
           {% if bool(user.nsfw) == True %}
             NSFW.
             <input type="hidden" name="nsfw" value="0">
-            <input class="flag-nsfw-button" type="submit" value="Remove NSFW Flag">
+            <input class="btn btn-small btn-pastel btn-primary flag-nsfw-button" type="submit" value="Remove NSFW Flag">
           {% else %}
             SFW.
             <input type="hidden"  name="nsfw"  value="1">
-            <input class="unflag-nsfw-button" type="submit" value="Set NSFW Flag">
+            <input class="btn btn-small btn-pastel btn-primary unflag-nsfw-button" type="submit" value="Set NSFW Flag">
           {% end %}
         </form>
 

--- a/templates/admin/nsfw-users.html
+++ b/templates/admin/nsfw-users.html
@@ -34,11 +34,11 @@
           {% if bool(user.nsfw) == True %}
             NSFW.
             <input type="hidden" name="nsfw" value="0">
-            <input class="flag-nsfw-button" type="submit" value="Remove NSFW Flag">
+            <input class="btn btn-small btn-pastel btn-primary flag-nsfw-button" type="submit" value="Remove NSFW Flag">
           {% else %}
             SFW.
             <input type="hidden"  name="nsfw"  value="1">
-            <input class="unflag-nsfw-button" type="submit" value="Set NSFW Flag">
+            <input class="btn btn-small btn-pastel btn-primary unflag-nsfw-button" type="submit" value="Set NSFW Flag">
           {% end %}
         </form>
 

--- a/templates/admin/shake-categories.html
+++ b/templates/admin/shake-categories.html
@@ -23,15 +23,23 @@
     <p>
       Save A New Category
     </p>
-    <form method="POST" action="/admin/shake-categories">
-      {{ xsrf_form_html() }}
+    <form class="fun-form fun-form-stacked" method="POST" action="/admin/shake-categories">
+        {{ xsrf_form_html() }}
 
-      Name: <input type="text" name="name"><br>
-      Short name: <input type="text" name="short_name" ><br>
-      <input type="submit" value="save it">
+        <div class="field">
+            <label>Name:</label>
+            <div class="field-input"><input class="input-text" type="text" name="name"></div>
+        </div>
+        <div class="field">
+            <label>Short name:</label>
+            <div class="field-input"><input class="input-text" type="text" name="short_name" ></div>
+        </div>
+        <div class="field field-submit">
+            <input class="btn btn-primary btn-shadow" type="submit" value="save it">
+        </div>
     </form>
     <p>
-      <a href="/admin/">&lt; Back to the Admin</a>
+      <a class="btn btn-pastel btn-secondary" href="/admin/">&lt; Back to the Admin</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
This commit prevents long strings from breaking the layout on admin
pages, such as shake titles or descriptions.

fixes #349