### PR TITLE
Prevent Forcible Resizing of Quick Comment Box

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -805,7 +805,7 @@ $(document).ready(function() {
           this.$comment_textarea.val('');
         }
         this.click_more_comments();
-        this.$comment_textarea.css('height', '60px');
+        this.$comment_textarea.css('min-height', '60px');
       },
 
       refresh_likes: function() {


### PR DESCRIPTION
This commit prevents an odd behavior where if you resized the quick
comment textarea, it would snap back to the original size. This was
definitely a bug, caused by an old bit of code to expand the textarea
when the user clicked into it. By changing `height` to `min-height`
the intended behavior is preserved, but users can make the textarea
larger if needed.

fixes #343