### PR TITLE
Show Sidebar First on Mobile

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -450,8 +450,7 @@ a:active {
 }
 
 .content-with-sidebar .sidebar {
-  background: linear-gradient(to top, rgba(255,255,255,0), #fff calc(100% - 6px), #eee);
-  order: 2;
+  background: linear-gradient(to bottom, rgba(255,255,255,0), #fff calc(100% - 6px), #eee);
   padding: 1.25em;
 }
 
@@ -464,7 +463,6 @@ a:active {
   .content-with-sidebar .sidebar {
     background: linear-gradient(to right, rgba(255,255,255,0), #fff calc(100% - 6px), #eee);
     flex-basis: 285px;
-    order: 0;
   }
 
   .content-with-sidebar-reversed .sidebar {


### PR DESCRIPTION
This commit reverses the displayed order of the sidebar and body
content on small screens, to make it easier to see stats and
notification blocks without having to scroll past all content.

fixes #289