### PR TITLE
Convert Remaining Buttons to Button Component

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -317,7 +317,7 @@ $(document).ready(function() {
     // Inline editing of the title.
     $(".image-edit-title-form .cancel").click(function() {
       $(this).closest('.image-title').find(".image-edit-title").show();
-      $(this).closest(".image-edit-title-form").hide();
+      $(this).closest(".image-edit-title-form").removeClass('is-active');
       return false;
     });
 
@@ -336,7 +336,7 @@ $(document).ready(function() {
         if ('title_raw' in result) {
           $(that).hide();
           $title_container.find('.title-input').val(result['title_raw']);
-          $(that).next(".image-edit-title-form").show();
+          $(that).next(".image-edit-title-form").addClass('is-active');
         }
       }, 'json');
 
@@ -351,7 +351,7 @@ $(document).ready(function() {
           var $title_container = $(that).closest('.image-title');
           $title_container.find('.image-edit-title').html(result['title']).show();
           $title_container.find('.title-input').val(result['title_raw']);
-          $title_container.find('.image-edit-title-form').hide();
+          $title_container.find('.image-edit-title-form').removeClass('is-active');
         }
       }, 'json');
       return false;
@@ -1551,7 +1551,7 @@ $(document).ready(function() {
         select_user: function(user_name) {
           this.clear_results();
           $input_field.val(user_name);
-          $invite_button.removeClass('invite-button-inactive');
+          $invite_button.removeAttr('disabled');
         },
 
         submit_form: function(ev) {
@@ -1570,11 +1570,11 @@ $(document).ready(function() {
 
         clear_input: function() {
           $input_field.val('');
-          $invite_button.addClass('invite-button-inactive');
+          $invite_button.attr('disabled', 'disabled');
         },
 
         send_invite: function() {
-          if ($invite_button.hasClass('invite-button-inactive')) {
+          if ($invite_button.disabled) {
             return false;
           } else {
             var url = $form.attr('action');

--- a/static/sass/_buttons.scss
+++ b/static/sass/_buttons.scss
@@ -1,0 +1,235 @@
+//
+// Buttons
+//
+.btn,
+.label {
+    border: none;
+    border-radius: .5em;
+    color: #fff;
+    cursor: pointer;
+    display: inline-block;
+    font-size: 18px;
+    font-weight: 500;
+    height: 2.2em;
+    letter-spacing: .033em;
+    line-height: 2.2em;
+    padding: 0 .88em;
+    text-align: center;
+    text-decoration: none;
+    text-shadow: .05em .05em .05em rgba(0, 0, 0, .5);
+    transition-duration: .2s;
+    transition-property: background-color, color;
+    user-select: none;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
+.label {
+    cursor: default;
+}
+
+.btn:hover,
+.btn:focus {
+    color: #fff;
+}
+
+.btn:focus {
+    outline: none; // this is safe because we've ensured good focus styles
+}
+
+// buttons with muted colors
+.btn-pastel,
+.label-pastel {
+    font-weight: 600;
+    letter-spacing: 0.015em;
+    text-shadow: none;
+}
+
+// buttons with shadows
+.btn-shadow {
+    box-shadow: .22em .22em 0 rgba(0, 0, 0, .125);
+    margin-right: .22em;
+}
+
+// buttons with extra padding
+.btn-padded {
+    height: 2.6em;
+    line-height: 2.6em;
+    padding: 0 1.25em;
+}
+
+// button size variations
+.btn-large,
+.label-large {
+    font-size: 24px;
+    letter-spacing: .066em;
+}
+
+.btn-large.btn-pastel,
+.label-large.label-pastel {
+    letter-spacing: 0.033em;
+}
+
+.btn-small,
+.btn-tiny,
+.label-small,
+.label-tiny {
+    font-size: 12px;
+    font-weight: 400;
+}
+
+.btn-tiny,
+.label-tiny {
+    font-size: 10px;
+    padding: 0 .66em;
+}
+
+.btn-small.btn-pastel,
+.btn-tiny.btn-pastel,
+.label-small.label-pastel,
+.label-tiny.label-pastel {
+    font-weight: 500;
+}
+
+// buttons that only contain an icon
+.btn-icon {
+    padding: 0;
+    width: 2.2em;
+}
+
+.btn-icon.btn-padded {
+    padding: 0;
+    width: 2.6em;
+}
+
+// Primary: Provides extra visual weight and identifies the primary action in a set of buttons
+.btn-primary,
+.label-primary {
+    background-color: $color-primary;
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+    background-color: $color-primary-hover;
+}
+
+.btn-primary.btn-pastel,
+.label-primary.label-pastel {
+    background-color: $color-primary-pastel-bg;
+    color: $color-primary-pastel-fg;
+}
+
+.btn-primary.btn-pastel:hover,
+.btn-primary.btn-pastel:focus {
+    background-color: $color-primary;
+    color: #fff;
+}
+
+// Secondary: De-emphasizes and identifies secondary actions in a set of buttons
+.btn-secondary,
+.label-secondary {
+    background-color: $color-secondary;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+    background-color: $color-secondary-hover;
+}
+
+.btn-secondary.btn-pastel,
+.label-secondary.label-pastel {
+    background-color: $color-secondary-pastel-bg;
+    color: $color-secondary-pastel-fg;
+}
+
+.btn-secondary.btn-pastel:hover,
+.btn-secondary.btn-pastel:focus {
+    background-color: $color-secondary;
+    color: #fff;
+}
+
+// Success: Indicates a successful or positive action
+.btn-success,
+.label-success {
+    background-color: $color-success;
+}
+
+.btn-success:hover,
+.btn-success:focus {
+    background-color: $color-success-hover;
+}
+
+.btn-success.btn-pastel,
+.label-success.label-pastel {
+    background-color: $color-success-pastel-bg;
+    color: $color-success-pastel-fg;
+}
+
+.btn-success.btn-pastel:hover,
+.btn-success.btn-pastel:focus {
+    background-color: $color-success;
+    color: #fff;
+}
+
+// Warning: Indicates caution should be taken with this action
+.btn-warning,
+.label-warning {
+    background-color: $color-warning;
+}
+
+.btn-warning:hover,
+.btn-warning:focus {
+    background-color: $color-warning-hover;
+}
+
+.btn-warning.btn-pastel,
+.label-warning.label-pastel {
+    background-color: $color-warning-pastel-bg;
+    color: $color-warning-pastel-fg;
+}
+
+.btn-warning.btn-pastel:hover,
+.btn-warning.btn-pastel:focus {
+    background-color: $color-warning;
+    color: #fff;
+}
+
+// Danger: Indicates a dangerous or potentially negative action
+.btn-danger,
+.label-danger {
+    background-color: $color-danger;
+}
+
+.btn-danger:hover,
+.btn-danger:focus {
+    background-color: $color-danger-hover;
+}
+
+.btn-danger.btn-pastel,
+.label-danger.label-pastel {
+    background-color: $color-danger-pastel-bg;
+    color: $color-danger-pastel-fg;
+}
+
+.btn-danger.btn-pastel:hover,
+.btn-danger.btn-pastel:focus {
+    background-color: $color-danger;
+    color: #fff;
+}
+
+// Disabled: buttons that cannot be used
+.btn:disabled {
+    background-color: $color-disabled !important;
+    color: rgba(255, 255, 255, .8) !important;
+    text-shadow: none;
+    cursor: default;
+}
+
+.btn.btn-pastel:disabled {
+    background-color: $color-disabled-pastel-bg !important;
+    color: $color-disabled-pastel-fg !important;
+}
+
+.btn.btn-shadow:disabled {
+    box-shadow: none !important;
+}

--- a/static/sass/_variables.scss
+++ b/static/sass/_variables.scss
@@ -1,24 +1,31 @@
+@function tint($color, $percent) {
+  @return mix(#fff, $color, $percent);
+}
+@function shade($color, $percent) {
+  @return mix(#000, $color, $percent);
+}
+
 $color-mltshp-pink: #ff0080;
 $color-mltshp-blue: #00aeff;
 
-$color-primary: #ff028b;
-$color-primary-hover: #df0196;
+$color-primary: $color-mltshp-pink;
+$color-primary-hover: shade($color-primary, 20%);
 $color-primary-pastel-bg: #ffcce8;
 $color-primary-pastel-fg: $color-primary;
-$color-secondary: #12bbfc;
-$color-secondary-hover: #0493F3;
+$color-secondary: $color-mltshp-blue;
+$color-secondary-hover: shade($color-secondary, 20%);
 $color-secondary-pastel-bg: #daf3ff;
-$color-secondary-pastel-fg: #00adff;
+$color-secondary-pastel-fg: $color-secondary;
 $color-success: #09B896;
-$color-success-hover: #08a687;
+$color-success-hover: shade($color-success, 20%);
 $color-success-pastel-bg: #b9ff8d;
 $color-success-pastel-fg: #0caf8b;
 $color-warning: #ff9600;
-$color-warning-hover: #eb8a00;
+$color-warning-hover: shade($color-warning, 20%);
 $color-warning-pastel-bg: #ffe466;
 $color-warning-pastel-fg: $color-warning;
 $color-danger: #f30;
-$color-danger-hover: #e62e00;
+$color-danger-hover: shade($color-danger, 20%);
 $color-danger-pastel-bg: #ffd4d4;
 $color-danger-pastel-fg: #ff1c1c;
 $color-disabled: #A1A1A1;
@@ -27,8 +34,8 @@ $color-disabled-pastel-fg: #8d8d87;
 
 $color-edit: rgba(#fcff00, 0.66);
 
-$link-color: #42b4ff; // this should probably be mltshp blue
-$link-color-hover: #0088f1;
+$link-color: $color-secondary;
+$link-color-hover: $color-secondary-hover;
 
-$link-color-primary: $color-mltshp-pink;
+$link-color-primary: $color-primary;
 $link-color-primary-hover: $color-primary-hover;

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -1,4 +1,5 @@
 @import "variables";
+@import "buttons";
 
 * {
     box-sizing: border-box;
@@ -126,7 +127,7 @@ a:active {
 /* actions toolbar */
 .site-nav {
     flex: 1;
-    margin-top: 65px;
+    margin-top: 69px;
     position: relative;
     text-align: right;
 }
@@ -134,10 +135,6 @@ a:active {
 /* ---------------------------------------------------------------------
   Site Nav Layout
 --------------------------------------------------------------------- */
-.site-nav--toggle {
-    display: inline-block;
-}
-
 .site-nav--list {
     display: none;
     flex-direction: column;
@@ -234,16 +231,7 @@ a:active {
     z-index: 3;
 }
 
-/* TODO: Make this a reusable button style */
 .choose-a-shake--toggle {
-    background-color: $color-success-pastel-bg;
-    border-radius: 10px;
-    border: none;
-    color: $color-success-pastel-fg;
-    font-size: 16px;
-    font-weight: bold;
-    padding: 13px 19px;
-    white-space: nowrap;
     width: 100%;
 }
 
@@ -252,6 +240,12 @@ a:active {
     border-bottom-right-radius: 0;
     box-shadow: 5px 5px 0 #e5e5e5;
     outline: none;
+
+    &:hover,
+    &:focus {
+        background: $color-success-pastel-bg;
+        color: $color-success-pastel-fg;
+    }
 }
 
 .choose-a-shake.is-expanded .choose-a-shake--toggle .caret {
@@ -268,7 +262,7 @@ a:active {
     padding: 1px 10px 10px 10px;
     position: absolute;
     right: 0;
-    top: 100%;
+    top: calc(100% - .22em);
 }
 
 .choose-a-shake.is-expanded .choose-a-shake--dropdown {
@@ -325,80 +319,21 @@ a:active {
 .choose-a-shake--dropdown .add-a-shake {
     display: block;
     float: right;
-    background-color: $color-success-pastel-fg;
     margin-top: 10px;
-    font-size: 12px;
-    font-weight: bold;
-    padding: 5px 10px;
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    border-radius: 5px;
-    color: #fff;
-    text-decoration: none;
-    text-shadow: 1px 1px 1px #0a8f72;
-}
-
-.choose-a-shake--dropdown .add-a-shake:hover {
-    background-color: #0a8f72;
 }
 
 /* ---------------------------------------------------------------------
   Site Nav Buttons
-  TODO: convert to reusable button styles
 --------------------------------------------------------------------- */
-
-/* site nav toggle */
-.site-nav--toggle {
-    background-color: $color-warning-pastel-bg;
-    border-radius: 10px;
-    border: none;
-    color: $color-warning;
-    cursor: pointer;
-    font-size: 16px;
-    font-weight: bold;
-    height: 42px;
-    line-height: 42px;
-    padding: 0;
-    text-decoration: none;
-    transition: background-color .15s ease, color .15s ease;
-    width: 42px;
-}
-
-.site-nav--toggle:hover,
-.site-nav--toggle:focus {
-    color: $color-mltshp-pink;
-    background-color: $color-edit;
-    outline: none;
-}
 
 /* your conversations button */
 .site-nav--conversations a {
-    background-color: $color-success-pastel-bg;
-    border-radius: 10px;
-    color: $color-success-pastel-fg;
     display: block;
-    font-size: 16px;
-    font-weight: bold;
-    padding: 13px 20px;
-    text-decoration: none;
-    white-space: nowrap;
 }
 
 /* popular button */
 .site-nav--popular a {
-    background-color: $color-warning-pastel-bg;
-    border-radius: 10px;
-    color: $color-warning;
     display: block;
-    font-size: 16px;
-    font-weight: bold;
-    padding: 13px 20px;
-    text-decoration: none;
-}
-
-.site-nav--popular a:hover {
-    color: $color-mltshp-pink;
-    background-color: $color-edit;
 }
 
 /* sign up button call-out text */
@@ -1282,34 +1217,6 @@ iframe {
     margin-top: 1em;
 }
 
-/* TODO: replace with reusable button styles */
-.content-migrate .button {
-    color: #fff;
-    font-size: 23px;
-    padding: 20px;
-    text-decoration: none;
-    font-weight: bold;
-    float: left;
-    display: block;
-    text-shadow: 1px 1px 1px #bf0060;
-    background-color: $color-mltshp-pink;
-    appearance: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
-    -webkit-border-radius: 10px;
-    -moz-border-radius: 10px;
-    border-radius: 10px;
-    border: 1px solid $color-mltshp-pink;
-    -moz-box-shadow: 5px 5px 0px rgba(0, 0, 0, 0.25);
-    -webkit-box-shadow: 5px 5px rgba(0, 0, 0, 0.25);
-    box-shadow: 5px 5px 0px rgba(0, 0, 0, 0.25);
-    cursor: pointer;
-}
-
-.content-migrate .button:hover {
-    background-color: #db008b;
-}
-
 .content-migrate p {
     line-height: 1.4;
     font-size: 20px;
@@ -1959,19 +1866,6 @@ iframe {
     margin-right: 8px;
 }
 
-/* TODO replace with reusable button styles */
-.permalink-sidebar .in-these-shakes .add-to-shakes-button {
-    background-color: $color-success-pastel-fg;
-    color: #fff;
-    border: 1px solid $color-success-pastel-fg;
-    padding: 4px 8px;
-    font-size: 14px;
-    margin-top: 10px;
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    border-radius: 5px;
-}
-
 .permalink-sidebar .permalink-social {
     margin: 0;
     padding: 0;
@@ -2617,7 +2511,7 @@ iframe {
     border-radius: 5px;
     border: 1px solid #e0e0e0;
     background-color: #fff;
-    padding: 5px 5px 5px 0;
+    padding: 5px;
     position: relative;
     display: flex;
 }
@@ -2672,39 +2566,11 @@ iframe {
 .shake-invite-member-block .input-text {
     border-radius: 5px;
     border: 1px solid #fff;
-    padding: 5px;
-    height: 16px;
     flex: 1;
 }
 
-/* TODO replace with reusable button styles */
 .shake-invite-member-block .invite-button {
-    border: 1px solid #00d517;
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    border-radius: 5px;
-    padding: 7px 10px;
-    background-color: #00d517;
-    font-size: 12px;
-    color: #fff;
-    font-weight: bold;
-    display: block;
-    float: left;
     margin-left: 5px;
-    text-decoration: none;
-    text-shadow: 1px 1px 1px #00a414;
-}
-
-.shake-invite-member-block .invite-button:focus {
-    outline: none;
-}
-
-.shake-invite-member-block .invite-button-inactive {
-    background-color: #e0e0e0;
-    color: #999;
-    text-shadow: none;
-    border: 1px solid #e0e0e0;
-    cursor: default;
 }
 
 .content-shake .shake-members {
@@ -3151,61 +3017,61 @@ iframe {
 
 .image-edit-title-form {
     display: none;
+    flex-direction: column;
+
+    &.is-active {
+        display: flex;
+    }
+}
+
+@media screen and (min-width: 480px) {
+    .image-edit-title-form {
+        flex-direction: row;
+    }
+}
+
+.image-content-list .image-edit-title-form {
     margin-bottom: 20px;
 }
 
 .image-content-list .image-edit-title-form .title-input {
     font-size: 30px;
     font-weight: bold;
-    border: 1px solid #ccc;
     padding: 2px;
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    border-radius: 5px;
+    min-width: 250px;
 }
 
 .image-edit-title-form .title-input {
     font-size: 48px;
     font-weight: bold;
+    border: 1px solid #ccc;
+    margin-bottom: 10px;
+    min-width: 0;
     max-width: 100%;
+    border-radius: 5px;
+    flex: 1;
 }
 
-/* TODO replace with reusable button styles */
+@media screen and (min-width: 480px) {
+    .image-edit-title-form .title-input {
+        margin-bottom: 0;
+    }
+}
+
 .image-edit-title-form .buttons {
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-left: 10px;
     display: flex;
-}
-
-.image-edit-title-form .save {
-    -webkit-border-radius: 10px;
-    -moz-border-radius: 10px;
-    border-radius: 10px;
-    border: 1px solid $color-mltshp-pink;
-    background-color: $color-mltshp-pink;
-    color: #fff;
-    font-size: 18px;
-    font-weight: bold;
-    padding: 10px 20px;
+    align-items: center;
 }
 
 .image-edit-title-form .or {
-    padding: 10px;
+    padding: 0 10px;
     display: block;
     color: #888;
 }
 
-.image-edit-title-form .cancel {
-    -webkit-border-radius: 10px;
-    -moz-border-radius: 10px;
-    border-radius: 10px;
-    border: 1px solid #e0e0e0;
-    background-color: #f5f5f5;
-    color: #666;
-    font-size: 18px;
-    font-weight: bold;
-    padding: 10px 20px;
-    text-decoration: none;
+.image-content-list .image-edit-title-form .btn {
+    @extend .btn-small;
 }
 
 /* Inline Editing Description */
@@ -3252,40 +3118,20 @@ textarea {
 
 .image-content .description .buttons {
     padding: 10px 0;
+    display: flex;
 }
 
-/* TODO replace with reusable button styles */
 .image-content .description .buttons .save {
-    -webkit-border-radius: 10px;
-    -moz-border-radius: 10px;
-    border-radius: 10px;
-    border: 1px solid $color-mltshp-pink;
-    background-color: $color-mltshp-pink;
-    color: #fff;
-    font-size: 12px;
-    text-decoration: none;
-    padding: 5px 10px;
-    float: left;
 }
 
 .image-content .description .buttons .or {
-    float: left;
     padding: 5px 10px 15px 10px;
     display: block;
     color: #888;
 }
 
 .image-content .description .buttons .cancel {
-    -webkit-border-radius: 10px;
-    -moz-border-radius: 10px;
-    border-radius: 10px;
-    border: 1px solid #e0e0e0;
-    background-color: #f5f5f5;
-    color: #666;
-    font-size: 12px;
-    padding: 5px 10px;
-    text-decoration: none;
-    float: left;
+    color: #fff;
 }
 
 .image-content .inline-details {
@@ -3441,17 +3287,6 @@ textarea {
 
 .image-content .inline-details .post-comment-inline-expanded .button {
     display: block;
-}
-
-/* TODO replace with reusable button styles */
-.image-content .inline-details .post-comment-inline .button input {
-    background-color: #ff0099;
-    color: #fff;
-    -webkit-border-radius: 5px;
-    -moz-border-radius: 5px;
-    border-radius: 5px;
-    padding: 5px;
-    border: none;
 }
 
 /*----------------------------------------------
@@ -4302,47 +4137,6 @@ span.previous-link {
     padding-bottom: 30px;
 }
 
-/* TODO replace with reusable button styles */
-.api-accept-button {
-    background-color: $color-mltshp-pink;
-    text-shadow: 1px 1px 1px #B5005A;
-    color: #fff;
-    font-weight: bold;
-    padding: 10px 20px;
-    border: none;
-    -webkit-border-radius: 10px;
-    -moz-border-radius: 10px;
-    border-radius: 10px;
-    -moz-box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.1);
-    -webkit-box-shadow: 4px 4px rgba(0, 0, 0, 0.1);
-    box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.1);
-}
-
-.api-accept-button:hover {
-    cursor: pointer;
-    background-color: #DB008B;
-}
-
-.api-decline-button {
-    background-color: #e0e0e0;
-    color: #666;
-    text-shadow: 1px 1px 1px #fff;
-    font-weight: bold;
-    padding: 10px 20px;
-    border: none;
-    -webkit-border-radius: 10px;
-    -moz-border-radius: 10px;
-    border-radius: 10px;
-    -moz-box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.05);
-    -webkit-box-shadow: 4px 4px rgba(0, 0, 0, 0.05);
-    box-shadow: 4px 4px 0px rgba(0, 0, 0, 0.05);
-}
-
-.api-decline-button:hover {
-    cursor: pointer;
-    background-color: #ccc;
-}
-
 /*----------------------------------------------
   Area: Developer
 ---------------------------------------------- */
@@ -4629,40 +4423,13 @@ span.previous-link {
     margin-top: 5px;
     margin-bottom: 10px;
     float: left;
-}
-
-/* TODO replace with reusable button styles */
-.shake-details .save {
-    -webkit-border-radius: 10px;
-    -moz-border-radius: 10px;
-    border-radius: 10px;
-    border: 1px solid $color-mltshp-pink;
-    background-color: $color-mltshp-pink;
-    color: #fff;
-    font-size: 14px;
-    font-weight: normal;
-    padding: 5px 10px;
-    float: left;
+    display: flex;
 }
 
 .shake-details .or {
-    float: left;
     padding: 5px;
     display: block;
     color: #888;
-}
-
-.shake-details .cancel {
-    -webkit-border-radius: 10px;
-    -moz-border-radius: 10px;
-    border-radius: 10px;
-    border: 1px solid #e0e0e0;
-    background-color: #f5f5f5;
-    color: #666;
-    font-size: 14px;
-    padding: 5px 10px;
-    text-decoration: none;
-    float: left;
 }
 
 .shake-sidebar-editor-block {
@@ -5015,238 +4782,6 @@ ul.promotions .promotion-name {
 }
 ul.promotions li:hover .promotion-name {
     display: inherit;
-}
-
-/*----------------------------------------------------------------------
-  Buttons
---------------------------------------------------------------------- */
-.btn,
-.label {
-    border: none;
-    border-radius: .5em;
-    color: #fff;
-    cursor: pointer;
-    display: inline-block;
-    font-size: 18px;
-    font-weight: 500;
-    height: 2.2em;
-    letter-spacing: .033em;
-    line-height: 2.2em;
-    padding: 0 .88em;
-    text-align: center;
-    text-decoration: none;
-    text-shadow: .05em .05em .05em rgba(0, 0, 0, .5);
-    transition-duration: .2s;
-    transition-property: background-color, color;
-    user-select: none;
-    vertical-align: middle;
-    white-space: nowrap;
-}
-
-.label {
-    cursor: default;
-}
-
-.btn:hover,
-.btn:focus {
-    color: #fff;
-}
-
-/* buttons with muted colors */
-.btn-pastel,
-.label-pastel {
-    font-weight: 600;
-    letter-spacing: 0.015em;
-    text-shadow: none;
-}
-
-/* buttons with shadows */
-.btn-shadow {
-    box-shadow: .22em .22em 0 rgba(0, 0, 0, .125);
-    margin-right: .22em;
-}
-
-/* buttons with extra padding */
-.btn-padded {
-    height: 2.6em;
-    line-height: 2.6em;
-    padding: 0 1.25em;
-}
-
-/* button size variations */
-.btn-large,
-.label-large {
-    font-size: 24px;
-    letter-spacing: .066em;
-}
-
-.btn-large.btn-pastel,
-.label-large.label-pastel {
-    letter-spacing: 0.033em;
-}
-
-.btn-small,
-.btn-tiny,
-.label-small,
-.label-tiny {
-    font-size: 12px;
-    font-weight: 400;
-}
-
-.btn-tiny,
-.label-tiny {
-    font-size: 10px;
-    padding: 0 .66em;
-}
-
-.btn-small.btn-pastel,
-.btn-tiny.btn-pastel,
-.label-small.label-pastel,
-.label-tiny.label-pastel {
-    font-weight: 500;
-}
-
-/* buttons that only contain an icon */
-.btn-icon {
-    padding: 0;
-    width: 2.2em;
-}
-
-.btn-icon.btn-padded {
-    padding: 0;
-    width: 2.6em;
-}
-
-/* Primary: Provides extra visual weight and identifies the primary action in a set of buttons */
-.btn-primary,
-.label-primary {
-    background-color: $color-primary;
-}
-
-.btn-primary:hover,
-.btn-primary:focus {
-    background-color: $color-primary-hover;
-}
-
-.btn-primary.btn-pastel,
-.label-primary.label-pastel {
-    background-color: $color-primary-pastel-bg;
-    color: $color-primary-pastel-fg;
-}
-
-.btn-primary.btn-pastel:hover,
-.btn-primary.btn-pastel:focus {
-    background-color: $color-primary;
-    color: #fff;
-}
-
-/* Secondary: De-emphasizes and identifies secondary actions in a set of buttons */
-.btn-secondary,
-.label-secondary {
-    background-color: $color-secondary;
-}
-
-.btn-secondary:hover,
-.btn-secondary:focus {
-    background-color: $color-secondary-hover;
-}
-
-.btn-secondary.btn-pastel,
-.label-secondary.label-pastel {
-    background-color: $color-secondary-pastel-bg;
-    color: $color-secondary-pastel-fg;
-}
-
-.btn-secondary.btn-pastel:hover,
-.btn-secondary.btn-pastel:focus {
-    background-color: $color-secondary;
-    color: #fff;
-}
-
-/* Success: Indicates a successful or positive action */
-.btn-success,
-.label-success {
-    background-color: $color-success;
-}
-
-.btn-success:hover,
-.btn-success:focus {
-    background-color: $color-success-hover;
-}
-
-.btn-success.btn-pastel,
-.label-success.label-pastel {
-    background-color: $color-success-pastel-bg;
-    color: $color-success-pastel-fg;
-}
-
-.btn-success.btn-pastel:hover,
-.btn-success.btn-pastel:focus {
-    background-color: $color-success;
-    color: #fff;
-}
-
-/* Warning: Indicates caution should be taken with this action */
-.btn-warning,
-.label-warning {
-    background-color: $color-warning;
-}
-
-.btn-warning:hover,
-.btn-warning:focus {
-    background-color: $color-warning-hover;
-}
-
-.btn-warning.btn-pastel,
-.label-warning.label-pastel {
-    background-color: $color-warning-pastel-bg;
-    color: $color-warning-pastel-fg;
-}
-
-.btn-warning.btn-pastel:hover,
-.btn-warning.btn-pastel:focus {
-    background-color: $color-warning;
-    color: #fff;
-}
-
-/* Danger: Indicates a dangerous or potentially negative action */
-.btn-danger,
-.label-danger {
-    background-color: $color-danger;
-}
-
-.btn-danger:hover,
-.btn-danger:focus {
-    background-color: $color-danger-hover;
-}
-
-.btn-danger.btn-pastel,
-.label-danger.label-pastel {
-    background-color: $color-danger-pastel-bg;
-    color: $color-danger-pastel-fg;
-}
-
-.btn-danger.btn-pastel:hover,
-.btn-danger.btn-pastel:focus {
-    background-color: $color-danger;
-    color: #fff;
-}
-
-/* Disabled: buttons that cannot be used */
-.btn:disabled {
-    background-color: $color-disabled !important;
-    color: rgba(255, 255, 255, .8) !important;
-    text-shadow: none;
-    cursor: default;
-}
-
-.btn.btn-pastel:disabled {
-    background-color: $color-disabled-pastel-bg !important;
-    color: $color-disabled-pastel-fg !important;
-}
-
-.btn.btn-shadow:disabled {
-    box-shadow: none !important;
 }
 
 /*----------------------------------------------------------------------

--- a/templates/account/migrate.html
+++ b/templates/account/migrate.html
@@ -11,7 +11,7 @@
 
     <form id="migration-form" action="/" method="GET">
     <input type="submit"
-      class="button" value="Take me home!" border="0">
+      class="btn btn-primary btn-shadow btn-large" value="Take me home!">
     </form>
     {% else %}
     <h2>Restore Your MLKSHK Content?</h2>
@@ -39,18 +39,17 @@
         <form id="migration-form" action="/account/mlkshk-migrate" method="POST">
         {{ xsrf_form_html() }}
         <input type="submit"
-          class="button" value="Restore It!" border="0">
+          class="btn btn-primary btn-shadow btn-large" value="Restore It!">
       </form>
     </div>
     <div style="float:left; margin-left: 20px">
       <form id="migration-form" action="/account/settings" method="GET">
       <input type="submit"
-        class="button" value="I&#x27;ll Decide Later!" border="0">
+        class="btn btn-primary btn-shadow btn-large" value="I&#x27;ll Decide Later!">
       </form>
     </div>
 
     {% end %}
 
-    <div class="clear"><!-- --></div>
   </div>
 {% end %}

--- a/templates/account/welcome-to-mltshp.html
+++ b/templates/account/welcome-to-mltshp.html
@@ -17,9 +17,8 @@
 
     <form action="/account/membership" method="GET">
        <input type="submit"
-         class="button" value="Select Membership" border="0">
+         class="btn btn-primary btn-shadow btn-large" value="Select Membership">
     </form>
 
-    <div class="clear"><!-- --></div>
   </div>
 {% end %}

--- a/templates/api/authorize.html
+++ b/templates/api/authorize.html
@@ -15,7 +15,7 @@
       {% if redirect_url %}
         <input type="hidden" name="redirect_uri" value="{{redirect_url}}">
       {% end %}
-      <input class="api-accept-button" type="submit" value="Agree">
+      <input class="api-accept-button btn btn-primary btn-shadow" type="submit" value="Agree">
     </form>
     <form class="api-decline" method="POST" action="/api/authorize?response_type=code&amp;client_id={{client_id}}">
       {{ xsrf_form_html() }}
@@ -23,7 +23,7 @@
       {% if redirect_url %}
         <input type="hidden" name="redirect_uri" value="{{redirect_url}}">
       {% end %}
-      <input class="api-decline-button" type="submit" value="Decline">
+      <input class="api-decline-button btn btn-secondary btn-shadow" type="submit" value="Decline">
     </form>
     <div class="clear"><!-- --></div>
   </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,18 +64,18 @@
                     <a href="/"><img class="site-branding--logo" src="{{ static_url("images/logo-compact.svg") }}" alt="MLTSHP"></a>
                 </div>
                 <nav id="site-nav" class="site-nav">
-                    <button type="button" class="site-nav--toggle">&#9776;</button>
+                    <button type="button" class="site-nav--toggle btn btn-warning btn-pastel btn-icon">&#9776;</button>
                     <ul class="site-nav--list">
                         {% if current_user and current_user_object.is_member() %}
                             <li class="site-nav--item site-nav--shake-list">
                                 {{modules.ShakeDropdown(current_user_object)}}
                             </li>
                             <li class="site-nav--item site-nav--conversations">
-                                <a href="/conversations">Your Conversations</a>
+                                <a class="btn btn-success btn-pastel" href="/conversations">Your Conversations</a>
                             </li>
                         {% else %}
                             <li class="site-nav--item site-nav--popular">
-                                <a href="/popular">Popular</a>
+                                <a class="btn btn-warning btn-pastel" href="/popular">Popular</a>
                             </li>
                         {% end %}
                         {% if not site_is_readonly %}

--- a/templates/image/quick-comments.html
+++ b/templates/image/quick-comments.html
@@ -43,7 +43,7 @@
       <input type="hidden" name="ajax" value="1">
         <textarea name="body">Write a comment&hellip;</textarea>
         <div class="button">
-          <input class="submit-comment-button" type="submit" value="Post It!">
+          <input class="submit-comment-button btn btn-primary btn-small" type="submit" value="Post It!">
         </div>
     </form>
   </div>

--- a/templates/image/show.html
+++ b/templates/image/show.html
@@ -98,7 +98,7 @@
             {% end %}
           {% end %}
           </ul>
-          <input type="submit" class="add-to-shakes-button" value="Add">
+          <input type="submit" class="add-to-shakes-button btn btn-success btn-small" value="Add">
           </form>
         </div>
       {% end %}

--- a/templates/shakes/_sidebar.html
+++ b/templates/shakes/_sidebar.html
@@ -32,9 +32,9 @@
         {{ xsrf_form_html() }}
         <input type="text" class="shake-edit-title-input" name="title" value=""/>
         <div class="buttons">
-          <input type="submit" class="save" value="Save">
+          <input type="submit" class="save btn btn-primary btn-small" value="Save">
           <span class="or">or</span>
-          <a href="" class="cancel">Cancel</a>
+          <a href="" class="cancel btn btn-secondary btn-small">Cancel</a>
         </div>
       </form>
     </div>
@@ -50,9 +50,9 @@
         {{ xsrf_form_html() }}
         <textarea class="shake-edit-description-input" name="description"></textarea>
         <div class="buttons">
-          <input type="submit" class="save" value="Save">
+          <input type="submit" class="save btn btn-primary btn-small" value="Save">
           <span class="or">or</span>
-          <a href="" class="cancel">Cancel</a>
+          <a href="" class="cancel btn btn-secondary btn-small">Cancel</a>
         </div>
       </form>
     </div>
@@ -87,8 +87,7 @@
           {{ xsrf_form_html() }}
           <div class="shake-input-wrapper">
             <input type="text" class="input-text" name="name">
-            <a href="" class="invite-button invite-button-inactive">Invite</a>
-            <div class="clear"><!-- --></div>
+            <button type="button" class="invite-button btn btn-success btn-small" disabled>Invite</button>
             <ul class="shake-results"></ul>
           </div>
         </form>

--- a/templates/uimodules/image.html
+++ b/templates/uimodules/image.html
@@ -10,9 +10,9 @@
     {{ xsrf_form_html() }}
     <input type="text" class="title-input" name="title"  autocomplete="off" value="">
     <div class="buttons">
-      <input type="submit" class="save" value="Save">
+      <input type="submit" class="save btn btn-primary" value="Save">
       <span class="or">or</span>
-      <a href="" class="cancel">Cancel</a>
+      <a href="" class="cancel btn btn-secondary">Cancel</a>
     </div>
   </form>
   {% else %}
@@ -81,9 +81,9 @@
           {{ xsrf_form_html() }}
         <textarea name="description" class="description-edit-textarea"></textarea>
         <div class="buttons">
-          <input type="submit" class="save" value="Save">
+          <input type="submit" class="save btn btn-primary btn-small" value="Save">
           <span class="or">or</span>
-          <a href="" class="cancel">Cancel</a>
+          <a href="" class="cancel btn btn-secondary btn-small">Cancel</a>
         </div>
       </form>
       {% else %}

--- a/templates/uimodules/shake-dropdown.html
+++ b/templates/uimodules/shake-dropdown.html
@@ -1,5 +1,5 @@
 <div id="choose-a-shake" class="choose-a-shake">
-  <button type="button" class="choose-a-shake--toggle">
+  <button type="button" class="choose-a-shake--toggle btn btn-success btn-pastel">
     Choose a shake
     <span class="caret"></span>
   </button>
@@ -19,7 +19,7 @@
       </ul>
     {% end %}
     {% if can_create_shake and not site_is_readonly %}
-      <a class="add-a-shake" href="/shake/create">+ Add a shake</a>
+      <a class="add-a-shake btn btn-success btn-small" href="/shake/create">+ Add a shake</a>
     {% end %}
   </div>
 </div>


### PR DESCRIPTION
This commit converts all remaining buttons to use the standard button
CSS component, ensuring that all buttons use the same styles.

It also removes the focus ring for buttons, since we know these buttons
have sufficently distinct hover/focus styles for keyboard users.

fixes #203
fixes #211
fixes #212