### PR TITLE
Enable Font Features for Headlines

### DIFF
--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -456,6 +456,19 @@ h6 {
     margin: 0;
 }
 
+h1,
+h2,
+h3 {
+    text-rendering: optimizeLegibility;
+    -webkit-font-kerning: normal;
+            font-kerning: normal;
+    -webkit-font-feature-settings: "kern" 1, "liga" 1, "clig" 1, "pnum" 1;
+            font-feature-settings: "kern" 1, "liga" 1, "clig" 1, "pnum" 1;
+    -webkit-font-variant-ligatures: common-ligatures;
+            font-variant-ligatures: common-ligatures;
+    font-variant-numeric: proportional-nums;
+}
+
 h1 {
     font-size: 48px;
     font-weight: bold;

--- a/templates/misc/styleguide.html
+++ b/templates/misc/styleguide.html
@@ -49,6 +49,17 @@
 
     <hr>
 
+    <h2 id="font-features">Font-Features</h2>
+    <p>We apply some font-features such as ligatures and kerning to headlines. Here's an example that should have it applied.</p>
+
+    <h1>LYoWAT - ff fi fl ffi Th</h1>
+    <h2>LYoWAT - ff fi fl ffi Th</h2>
+    <h3>LYoWAT - ff fi fl ffi Th</h3>
+
+    <p>Note that these features are not available in every font. In particular, our headlines use the system font stack, and these rules don't seem to have any affect on the Mac system font.</p>
+
+    <hr>
+
     <h2 id="media">Media</h2>
     <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore.</p>
 


### PR DESCRIPTION
This commit applies a set of font feature rules to headlines to enable
the browser to use kerning and ligatures. Unfortunately, this doesn't
have any effect on Mac since the system font doesn't support it, but
it shouldn't cause any problems to have these rules in case they start
working someday.

fixes #242