### PR TITLE
Fix for Bookmark display bugs

### DIFF
--- a/static/sass/components/_bookmark.scss
+++ b/static/sass/components/_bookmark.scss
@@ -13,7 +13,7 @@
 .bookmark-flag {
     flex: none;
     margin-top: -3px;
-    background: #ff0180;
+    background: $color-primary;
     color: #fff;
     font-weight: bold;
     font-size: 12px;
@@ -55,10 +55,11 @@
     line-height: 1;
 }
 
+// 1. this is less than the border width to avoid a gap due to pixel-rounding errors
 .bookmark-flag--content::after {
     top: 0;
-    right: -.866em;
-    border: 1em solid #ff0180;
+    right: -.833em; // 1
+    border: 1em solid $color-primary;
     border-width: 1em .866em 1em 0;
     border-right-color: transparent;
 }

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -94,7 +94,7 @@
         {% if show_notice_where_you_were %}
             <div class="bookmark">
               <span class="bookmark-flag">
-                <span>Here is where you were</span>
+                <span class="bookmark-flag--content">Here is where you were</span>
               </span>
             </div>
         {% end %}


### PR DESCRIPTION
1. fix for "here is where you were" bookmark not having any padding or
   tails on the bookmark.

2. fix for a 1px gap between bookmark content and tails due to
   sub-pixel rounding errors.

fixes #433
fixes #434