### PR TITLE
Show Real Dates as Tooltip on Relative Dates

### DIFF
--- a/models/bookmark.py
+++ b/models/bookmark.py
@@ -11,10 +11,10 @@ class Bookmark(Model):
     created_at   = Property()
     sharedfile_id = Property()
     previous_sharedfile_id = Property()
-    
+
     def __str__(self):
         return "Bookmark - id: %s, user_id: %s, created_at: %s" % (self.id, self.user_id, self.created_at)
-    
+
     def save(self, *args, **kwargs):
         if options.readonly:
             self.add_error('_', 'Site is read-only.')
@@ -28,7 +28,7 @@ class Bookmark(Model):
         if existing_previous_bookmark and existing_previous_bookmark[0].sharedfile_id > 0:
             self.previous_sharedfile_id = existing_previous_bookmark[0].sharedfile_id
             self.save()
-        
+
     def _set_dates(self):
         """
         Sets the created_at field unless it's already set.
@@ -41,10 +41,17 @@ class Bookmark(Model):
         A friendly version of the created_at date.
         """
         return pretty_date(self.created_at)
-        
+
+    def feed_date(self):
+        """
+        Returns a date formatted to be included in feeds
+        e.g., Tue, 12 Apr 2005 13:59:56 EST
+        """
+        return self.created_at.strftime("%a, %d %b %Y %H:%M:%S %Z")
+
     def sharedfile_key(self):
         return base36encode(self.sharedfile_id)
-        
+
     def previous_sharedfile_key(self):
         return base36encode(self.previous_sharedfile_id)
 
@@ -53,7 +60,7 @@ class Bookmark(Model):
         """
         Check if there is a bookmark newer than the sharedfile passed in, if not
         create a new one with current timestamp. Returns the newest bookmark.
-        
+
         If no sharedfile passed in, no bookmark gets created.
         """
         if not sharedfile:
@@ -72,25 +79,25 @@ class Bookmark(Model):
     def for_user_between_sharedfiles(self, user, sharedfiles):
         """
         Return list of bookmarks for a user between a list of ordered sharedfiles.
-        
+
         Method accepts a list of sharedfiles, ordered newer to older.
         We want a list of bookmarks that is in between or equal to the date range passed in.
-        
+
         We need at least two sharedfiles.  Bookmarks can't intersect with what start_reading
         would return.
         """
         if len(sharedfiles) < 2:
             return []
-        
+
         newest_date = sharedfiles[0].created_at.strftime("%Y-%m-%d %H:%M:%S")
         oldest_date = sharedfiles[-1].created_at.strftime("%Y-%m-%d %H:%M:%S")
-        return self.where("user_id = %s and created_at < %s and created_at >= %s order by created_at", 
+        return self.where("user_id = %s and created_at < %s and created_at >= %s order by created_at",
             user.id, newest_date, oldest_date)
-    
+
     @classmethod
     def merge_with_sharedfiles(self, bookmarks, sharedfiles):
         """
-        Sorts a list of bookmarks with a list of sharedfiles based on created_at.  
+        Sorts a list of bookmarks with a list of sharedfiles based on created_at.
         Bookmark will come before sharedfile if date is the same..
         """
         def compare_created_at(x, y):
@@ -99,12 +106,12 @@ class Bookmark(Model):
             elif x.created_at < y.created_at:
                 return 1
             else:
-                x_name = x.__class__.__name__ 
+                x_name = x.__class__.__name__
                 y_name = y.__class__.__name__
                 if x_name == 'Bookmark' and y_name == 'Sharedfile':
                     return -1
                 return 0
-                
+
         composite_list = sharedfiles + bookmarks
         composite_list.sort(compare_created_at)
         return composite_list

--- a/models/comment.py
+++ b/models/comment.py
@@ -94,6 +94,13 @@ class Comment(Model):
         """
         return pretty_date(self.created_at)
 
+    def feed_date(self):
+        """
+        Returns a date formatted to be included in feeds
+        e.g., Tue, 12 Apr 2005 13:59:56 EST
+        """
+        return self.created_at.strftime("%a, %d %b %Y %H:%M:%S %Z")
+
     def body_formatted(self):
         """
         An escaped and formatted body of the comment with \n replaced by HTML <br>

--- a/templates/conversations/index.html
+++ b/templates/conversations/index.html
@@ -35,7 +35,12 @@
                     </a>
                   </div>
                   <div class="body">
-                    <div class="meta"><a href="/user/{{comment.user().name}}" class="user-name">{{comment.user().name}}</a> <span class="created-at">{{comment.pretty_created_at()}}</span></div>
+                    <div class="meta">
+                        <a href="/user/{{comment.user().name}}" class="user-name">{{comment.user().name}}</a>
+                        <span class="created-at">
+                            <time datetime="{{comment.created_at}}" title="{{comment.feed_date()}}">{{comment.pretty_created_at()}}</time>
+                        </span>
+                    </div>
                     {{comment.body_formatted()}}
                   </div>
                 </div>

--- a/templates/conversations/mentions.html
+++ b/templates/conversations/mentions.html
@@ -29,9 +29,14 @@
                       </a>
                     </div>
                     <div class="body">
-                      <div class="meta"><a class="user-name" href="/user/{{mention['comment'].user().name}}">{{mention['comment'].user().name}}</a> <span class="created-at">{{mention['comment'].pretty_created_at()}}</span></div>
-                      {{mention['comment'].body_formatted()}}
-                      <div class="where-from">Posted on "<a href="/p/{{mention['sharedfile'].share_key}}">{{mention['sharedfile'].get_title()}}</a>"</div>
+                        <div class="meta">
+                            <a class="user-name" href="/user/{{mention['comment'].user().name}}">{{mention['comment'].user().name}}</a>
+                            <span class="created-at">
+                                <time datetime="{{mention['comment'].created_at}}" title="{{mention['comment'].feed_date()}}">{{mention['comment'].pretty_created_at()}}</time>
+                            </span>
+                        </div>
+                        {{mention['comment'].body_formatted()}}
+                        <div class="where-from">Posted on "<a href="/p/{{mention['sharedfile'].share_key}}">{{mention['sharedfile'].get_title()}}</a>"</div>
                     </div>
                     <div class="clear"><!-- --></div>
                   </div>

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -105,7 +105,10 @@
           {% else %}
             <div class="bookmark">
               <span class="bookmark-flag">
-                <span class="bookmark-flag--content">You started <span class="hide-on-small">reading</span> here {{sharedfile.pretty_created_at() }}</span>
+                <span class="bookmark-flag--content">
+                    You started <span class="hide-on-small">reading</span> here
+                    <time datetime="{{sharedfile.created_at}}" title="{{sharedfile.feed_date()}}">{{sharedfile.pretty_created_at()}}</time>
+                </span>
               </span>
               {% if sharedfile.previous_sharedfile_id > 0 %}
                 <span class="jump-back">

--- a/templates/image/quick-comments.html
+++ b/templates/image/quick-comments.html
@@ -14,7 +14,9 @@
             <img alt="pro" src="{{ static_url("images/icon_plus.svg") }}" width="12" height="12" border="0" valign="center">
           </a>
         {% end %}
-        <span class="created-at">{{comment.pretty_created_at()}}</span>
+        <span class="created-at">
+            <time datetime="{{comment.created_at}}" title="{{comment.feed_date()}}">{{comment.pretty_created_at()}}</time>
+        </span>
         {% if not site_is_readonly %}
           {% if current_user and current_user_object.email_confirmed == 1 %}
         <a class="reply-to" href="">Reply</a>

--- a/templates/image/show.html
+++ b/templates/image/show.html
@@ -179,7 +179,9 @@
                   <img src="{{ static_url("images/icon_plus.svg") }}" width="12" height="12" border="0" valign="center" alt="pro">
                 </a>
               {% end %}
-              <span class="created-at">{{comment.pretty_created_at()}}</span>
+              <span class="created-at">
+                  <time datetime="{{comment.created_at}}" title="{{comment.feed_date()}}">{{comment.pretty_created_at()}}</time>
+              </span>
               {% if not site_is_readonly %}
                 {% if can_comment %}
               <a class="reply-to" href="">Reply</a>

--- a/templates/uimodules/image.html
+++ b/templates/uimodules/image.html
@@ -141,9 +141,13 @@
                 <a class="user-name" href="/user/{{original_user.name}}">{{ original_user.name }}</a>
             </div>
         {% end %}
-        {% if list_view %}
-            <div class="inline-meta">
-                <span class="created-at"><a href="/p/{{sharedfile.share_key}}">{{sharedfile.pretty_created_at()}}</a></span>
+        <div class="inline-meta">
+            <span class="created-at">
+                <a href="/p/{{sharedfile.share_key}}">
+                    <time datetime="{{sharedfile.created_at}}" title="{{sharedfile.feed_date()}}">{{sharedfile.pretty_created_at()}}</time>
+                </a>
+            </span>
+            {% if list_view %}
                 <ul class="stats">
                     {% set view_count = sharedfile.livish_view_count() %}
                     <li class="views">{{view_count }} View{% if view_count != 1 %}s{% end %}</li>
@@ -151,7 +155,9 @@
                     <li class="likes"><a href="/p/{{sharedfile.share_key}}" id="like-count-amount-{{sharedfile.share_key}}">{{sharedfile.like_count }}</a></li>
                     <li class="comments {% if len(comments) > 0 %}selected{% end %}"><a href="/p/{{sharedfile.share_key}}#comments">{{sharedfile.comment_count() }}</a></li>
                 </ul>
-            </div>
+            {% end %}
+        </div>
+        {% if list_view %}
             {% if len(comments) > 0 %}
                 <div class="inline-details">
                     {% include '../image/quick-comments.html' %}
@@ -159,7 +165,7 @@
             {% else %}
                 <div class="inline-details" style="display:none;"></div>
             {% end %}
-            <div class="clear"><!-- --></div>
         {% end %}
+        <div class="clear"><!-- --></div>
     </div>
 </div>


### PR DESCRIPTION
This commit wraps all our relative dates (eg, "3 weeks ago") with a
proper HTML `date` element, with a `datetime` attribute containing the
ISO date, and a `title` attribute with a human-readable real date to
display as a tooltip on hover.

fixes #435