### PR TITLE
Commenting out ObjC library - no longer exists

### DIFF
--- a/templates/developers/index.html
+++ b/templates/developers/index.html
@@ -66,10 +66,12 @@
     <h2>API Reference</h2>
     <p>See the <a href="/developers/reference">reference documentation here</a>.</p>
 
+    <!--
     <h2>Other Resources</h2>
     <ul>
       <li><a href="https://github.com/abrahamvegh/ShakeKit">ShakeKit</a> is an Objective-C wrapper for the MLTSHP API.</li>
     </ul>
+    -->
    </div>
 </div>
 {% end %}

--- a/templates/developers/index.html
+++ b/templates/developers/index.html
@@ -65,13 +65,6 @@
     </p>
     <h2>API Reference</h2>
     <p>See the <a href="/developers/reference">reference documentation here</a>.</p>
-
-    <!--
-    <h2>Other Resources</h2>
-    <ul>
-      <li><a href="https://github.com/abrahamvegh/ShakeKit">ShakeKit</a> is an Objective-C wrapper for the MLTSHP API.</li>
-    </ul>
-    -->
    </div>
 </div>
 {% end %}


### PR DESCRIPTION
Was poking around, and looking into making an app for Mltshp, and saw that the link to this library is now broken. I'm commenting it out instead of deleting, in case of some other similar resource comes available in the future.