### PR TITLE
Fix Permalink Comment Form

### DIFF
--- a/static/sass/components/_image-comments.scss
+++ b/static/sass/components/_image-comments.scss
@@ -103,12 +103,15 @@
     padding-left: 40px;
 }
 
+.image-comment-form header {
+    display: flex;
+}
+
 .image-comment-form .avatar {
-    float: left;
+    flex: none;
 }
 
 .image-comment-form h3 {
-    float: left;
     display: block;
     background: transparent
         url('/static/images/comment-quip-left.svg')
@@ -131,7 +134,19 @@
     padding-left: 35px;
     padding-right: 20px;
     font-weight: bold;
-    font-size: 18px;
+    font-size: 12px;
+
+    @media screen and (min-width: 360px) {
+        font-size: 14px;
+    }
+
+    @media screen and (min-width: 480px) {
+        font-size: 16px;
+    }
+
+    @media screen and (min-width: 820px) {
+        font-size: 18px;
+    }
 }
 
 .image-comment-form .field {

--- a/templates/image/show.html
+++ b/templates/image/show.html
@@ -208,8 +208,10 @@
       <div id="post-comment" class="image-comment-form">
         <form action="/p/{{sharedfile.share_key}}/comment" method="post">
           {{ xsrf_form_html() }}
-            <img class="avatar avatar--img" src="{{current_user_obj.profile_image_url()}}" height="48" width="48" alt="">
-            <h3><span>I've got something to say!</span></h3>
+            <header>
+              <img class="avatar avatar--img" src="{{current_user_obj.profile_image_url()}}" height="48" width="48" alt="">
+              <h3><span>I've got something to say!</span></h3>
+            </header>
             <div class="field">
               <textarea id="post-comment-body" name="body"></textarea>
             </div>


### PR DESCRIPTION
This commit tweaks the permalink comment form to restore the gutter
between the header and the input, and also to make the headline look
better on smaller screens.

fixes #231
fixes #235