### PR TITLE
Move `Quit Shake` Button

### DIFF
--- a/static/sass/areas/_shakes.scss
+++ b/static/sass/areas/_shakes.scss
@@ -146,34 +146,41 @@
     color: $color-mltshp-pink;
 }
 
-.shake-sidebar-subscribe {
+.shake-sidebar-actions {
     margin-top: 10px;
     margin-bottom: 20px;
     display: flex;
+
+    > * {
+        flex: none;
+
+        + * {
+            margin-left: 10px;
+        }
+    }
 }
 
-.shake-sidebar-subscribe .user-follow {
+.shake-sidebar-actions .user-follow {
 }
 
-.shake-sidebar-subscribe .user-follow h4 a {
+.shake-sidebar-actions .user-follow h4 a {
     display: none;
 }
 
-.shake-sidebar-subscribe .request-invitation {
-    margin-left: 10px;
+.shake-sidebar-actions .request-invitation {
     font-size: 14px;
     color: #555;
     height: 27px;
 }
 
-.shake-sidebar-subscribe .request-invitation span {
+.shake-sidebar-actions .request-invitation span {
     padding-top: 5px;
     height: 22px;
     display: block;
 }
 
-.shake-sidebar-subscribe .icon,
-.shake-sidebar-subscribe .follow h4 {
+.shake-sidebar-actions .icon,
+.shake-sidebar-actions .follow h4 {
     display: none;
 }
 
@@ -198,9 +205,6 @@
     color: #333;
     font-size: 14px;
     line-height: 18px;
-}
-
-.shake-details .description .content {
     white-space: pre-wrap;
     word-wrap: break-word;
     overflow-wrap: break-word;
@@ -277,15 +281,4 @@
 
 .shake-sidebar-requests {
     margin: 20px 0;
-}
-
-.sidebar .quit-shake {
-    background-color: #fff;
-    margin-top: 20px;
-    color: #F09;
-    border: none;
-    text-decoration: none;
-    padding: 5px 10px 5px 12px;
-    font-size: 11px;
-    cursor: pointer;
 }

--- a/templates/shakes/_sidebar.html
+++ b/templates/shakes/_sidebar.html
@@ -64,17 +64,28 @@
   {% end %}
 
   {% if not site_is_readonly %}
-  <div class="shake-sidebar-subscribe">
+  <div class="shake-sidebar-actions">
+
     {{modules.ShakeFollow(follow_shake=shake, current_user=current_user_obj, avatar_size=100)}}
+
     {% if current_user_obj and current_user_obj.can_request_invitation_to_shake(shake.id) %}
       <div id="request-invitation" class="request-invitation">
         <form method="post" action="/shake/{{shake.name}}/request_invitation">
           {{ xsrf_form_html() }}
-          <input class="btn btn-success btn-shadow btn-small" type="submit" value="+ Join this shake">
+          <input class="btn btn-success btn-pastel btn-small" type="submit" value="+ Join this shake">
         </form>
       </div>
     {% end %}
-    <div class="clear"><!-- --></div>
+
+    {% if managers and is_shake_manager %}
+      <div class="quit-shake">
+        <form class="quit-shake-form" method="post" action="/shake/{{shake.name}}/quit">
+          {{ xsrf_form_html() }}
+          <input class="btn btn-danger btn-pastel btn-small" type="submit" class="quit-shake" id="quit-shake-page" value="Quit this shake?">
+        </form>
+      </div>
+    {% end %}
+
   </div>
 
   {{modules.NotificationInvitations(invitation)}}
@@ -124,14 +135,6 @@
       </ul>
     </div>
   </div>
-  <p>
-    {% if is_shake_manager and not site_is_readonly %}
-      <form class="quit-shake-form" method="post" action="/shake/{{shake.name}}/quit">
-        {{ xsrf_form_html() }}
-        <input type="submit" class="quit-shake" id="quit-shake-page" value="Quit this shake?">
-      </form>
-    {% end %}
-  </p>
   {% end %}
 
   <div class="following-wrapper">


### PR DESCRIPTION
This commit moves the "quit shake" button from the bottom of the shake
sidebar to near the middle, where the other action buttons for join and
follow currently are. It also changes it to use the standard button
styles, and properly wraps long strings in the shake description.

fixes #222