### PR TITLE
Improve Your Conversations Page for Small Screens

### DIFF
--- a/static/sass/components/_account-header.scss
+++ b/static/sass/components/_account-header.scss
@@ -22,11 +22,19 @@
 }
 
 .account-header h2 {
-    font-size: 42px;
+    font-size: 30px;
     line-height: 50px;
     font-weight: bold;
     padding-left: 24px;
     word-break: break-word;
     word-wrap: break-word;
     overflow-wrap: break-word;
+
+    @media screen and (min-width: 480px) {
+        font-size: 36px;
+    }
+
+    @media screen and (min-width: 800px) {
+        font-size: 42px;
+    }
 }

--- a/static/sass/components/_conversations.scss
+++ b/static/sass/components/_conversations.scss
@@ -30,10 +30,18 @@
 }
 
 .content-conversations .body h2 {
-    font-size: 48px;
+    font-size: 30px;
     color: #333;
     font-weight: bold;
     margin: 30px;
+
+    @media screen and (min-width: 480px) {
+        font-size: 36px;
+    }
+
+    @media screen and (min-width: 800px) {
+        font-size: 48px;
+    }
 }
 
 .conversation {
@@ -46,16 +54,19 @@
     padding-right: 10px;
 }
 
-@media screen and (min-width: 768px) {
-    .conversation {
-        display: flex;
-    }
+.conversation {
+    display: flex;
 }
 
 .conversation .thumb {
     flex: none;
-    width: 100px;
-    margin-left: 30px;
+    width: 50px;
+    margin-left: 10px;
+
+    @media screen and (min-width: 480px) {
+        width: 100px;
+        margin-left: 30px;
+    }
 }
 
 .conversation .details-wrapper {

--- a/static/sass/components/_conversations.scss
+++ b/static/sass/components/_conversations.scss
@@ -29,21 +29,6 @@
     text-decoration: none;
 }
 
-.content-conversations .body h2 {
-    font-size: 30px;
-    color: #333;
-    font-weight: bold;
-    margin: 30px;
-
-    @media screen and (min-width: 480px) {
-        font-size: 36px;
-    }
-
-    @media screen and (min-width: 800px) {
-        font-size: 48px;
-    }
-}
-
 .conversation {
     margin-top: 30px;
     border-bottom: 1px dotted #e0e0e0;

--- a/templates/conversations/index.html
+++ b/templates/conversations/index.html
@@ -4,6 +4,11 @@
 
 {% block main %}
   <div class="content content-with-sidebar content-conversations">
+    <div class="account-header">
+      <div class="avatar">
+        <h2>Your Conversations</h2>
+      </div>
+    </div>
     <div class="sidebar">
       <div class="conversations-nav">
         <h3>Looking for something?</h3>
@@ -16,8 +21,6 @@
       </div>
     </div>
     <div class="body">
-      <h2>Your Conversations</h2>
-
       {% for conversation in conversations %}
         <div class="conversation">
           <a class="thumb" href="/p/{{conversation['sharedfile'].share_key}}"><img src="{{ conversation['sharedfile'].thumbnail_url() }}"></a>

--- a/templates/conversations/mentions.html
+++ b/templates/conversations/mentions.html
@@ -4,6 +4,11 @@
 
 {% block main %}
   <div class="content content-with-sidebar content-conversations">
+    <div class="account-header">
+      <div class="avatar">
+        <h2>Your Mentions</h2>
+      </div>
+    </div>
     <div class="sidebar">
       <div class="conversations-nav">
         <h3>Looking for something?</h3>
@@ -16,7 +21,6 @@
       </div>
     </div>
     <div class="body">
-      <h2>Mentions</h2>
       <div class="mentions">
         {% for mention in mentions %}
           <div class="conversation">


### PR DESCRIPTION
This commit tweaks the styles on the Your Conversations page to work
better on small screens, including reducing the headline font size,
keeping the two-column layout, and reducing the size of the thumbnail.

fixes #227