### PR TITLE
Fix cancel error

### DIFF
--- a/handlers/account.py
+++ b/handlers/account.py
@@ -1018,15 +1018,16 @@ class PaymentCancelHandler(BaseHandler):
                     subscription = customer.subscriptions.data[0]
                     if subscription:
                         subscription.delete(at_period_end=True)
-                        user.stripe_plan_id = user.stripe_plan_id + "-canceled"
+                        if user.stripe_plan_id and ("-canceled" not in user.stripe_plan_id):
+                            user.stripe_plan_id = user.stripe_plan_id + "-canceled"
                         user.stripe_plan_rate = None
                         user.save()
 
                         if options.postmark_api_key:
                             pm = postmark.PMMail(api_key=options.postmark_api_key,
                                 sender="hello@mltshp.com", to="hello@mltshp.com",
-                                subject="%s has cancelled a subscription" % (user.display_name()),
-                                text_body="Subscription ID: %s\nBuyer Name:%s\nBuyer Email:%s\nUser ID:%s\n" % (sub["id"], user.display_name(), user.email, user.id))
+                                subject="%s has canceled a subscription" % (user.display_name()),
+                                text_body="Subscription ID: %s\nBuyer Name:%s\nBuyer Email:%s\nUser ID:%s\n" % (subscription.id, user.display_name(), user.email, user.id))
                             pm.send()
 
                         payment_notifications(user, 'cancellation')

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ kombu==4.0.2
 pycurl==7.43.0
 pyparsing==2.2.0
 python-dateutil==1.5
-python-postmark==0.3.1
+python-postmark==0.5.0
 recaptcha-client==1.0.6
 tornado==4.1
 torndb==0.3


### PR DESCRIPTION
Fixes a runtime error that occurs when a user elects to cancel their subscription. The error was happening during an email notification, so the cancelation already took place, but the user is left with an error screen thinking that it didn't work.