### PR TITLE
Updates for local development.

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -19,11 +19,9 @@ services:
         aliases:
           - mltshp.dev
   mysql:
-    image: mysql:latest
+    image: mysql:5
     ports:
       - "3306:3306"
-    volumes:
-      - ./setup/dev/mysql-conf.d:/etc/mysql/conf.d
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: "mltshp_testing"

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     image: mysql:latest
     ports:
       - "3306:3306"
+    volumes:
+      - ./setup/dev/mysql-conf.d:/etc/mysql/conf.d
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: "mltshp_testing"

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ app itself using:
 
 This will do a lot of things. But ultimately, you should end up with a
 copy of MLTSHP running locally. It expects to be accessed via a hostname
-of `mltshp.dev` and `s.mltshp.dev`. Add these entries to your `/etc/hosts`
+of `mltshp.local` and `s.mltshp.local`. Add these entries to your `/etc/hosts`
 file:
 
-    127.0.0.1   mltshp.dev s.mltshp.dev
+    127.0.0.1   mltshp.local s.mltshp.local
 
 The web app itself runs on port 8000. You should be able to reach it via:
 
-[http://mltshp.dev:8000/]()
+[http://mltshp.local:8000/]()
 
 Subsequent invocations of `make run` should be faster, once you have
 the dependency images downloaded.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     networks:
       app_net:
         aliases:
-          - mltshp.dev
+          - mltshp.local
   fakes3:
     image: fingershock/fakes3
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - "3306:3306"
     volumes:
       - ./mounts/mysql:/var/lib/mysql
+      - ./setup/dev/mysql-conf.d:/etc/mysql/conf.d
       - ./setup/db-install.sql:/docker-entrypoint-initdb.d/00_db-install.sql
       - ./setup/db-fixtures.sql:/docker-entrypoint-initdb.d/01_db-fixtures.sql
     environment:

--- a/handlers/image.py
+++ b/handlers/image.py
@@ -556,7 +556,7 @@ class OEmbedHandler(BaseHandler):
             parsed_url = urlparse(self.get_argument('url', None))
         except:
             raise tornado.web.HTTPError(404)
-        if parsed_url.netloc not in [options.app_host, 'mltshp.dev:8000', 'localhost:8000', 'localhost:81', 'www.' + options.app_host]:
+        if parsed_url.netloc not in [options.app_host, 'mltshp.local:8000', 'localhost:8000', 'localhost:81', 'www.' + options.app_host]:
             raise tornado.web.HTTPError(404)
         share_key = re.search("/p/([A-Za-z0-9]+)", parsed_url.path)
         if not share_key:

--- a/models/user.py
+++ b/models/user.py
@@ -256,8 +256,12 @@ hello@mltshp.com
                     protocol = 'https:'
                 else:
                     protocol = 'http:'
-            aws_url = "%s//%s.%s%s" % (protocol, options.aws_bucket, options.aws_host,
-                options.aws_port in (443, 80, None) and "" or (":%d" % options.aws_port))
+            if options.app_host == 'mltshp.com':
+                aws_url = "%s//%s.%s%s" % (protocol, options.aws_bucket, options.aws_host,
+                    options.aws_port in (443, 80, None) and "" or (":%d" % options.aws_port))
+            else:
+                # must be running for development. use the /s3 alias
+                aws_url = "/s3"
             return "%s/account/%s/profile.jpg" % (aws_url, self.id)
         else:
             if include_protocol:

--- a/settings.example.py
+++ b/settings.example.py
@@ -1,8 +1,8 @@
 # Development settings; suitable for running against our Docker
 # image.
 settings = {
-    "app_host": "mltshp.dev",
-    "cdn_host": "s.mltshp.dev",
+    "app_host": "mltshp.local",
+    "cdn_host": "s.mltshp.local",
     "api_hits_per_hour" : 150,
     "auth_secret" : "dummy-secret",
     "aws_bucket": "mltshp-dev",

--- a/setup/db-fixtures.sql
+++ b/setup/db-fixtures.sql
@@ -3,7 +3,8 @@
 -- auth_secret for local testing: dummy-secret
 INSERT INTO `user` (`name`, `disable_notifications`, `created_at`) VALUES ('mltshp', 1, now());
 -- password for "admin" is "password" if you're using the local testing auth_secret key
-INSERT INTO `user` (`name`, `hashed_password`, `email`, `full_name`, `email_confirmed`, `is_paid`) VALUES ('admin', '9bbdccf408a2420e20fcd157c6315d5f77427c64', 'admin@example.com', 'Site Admin', 1, 1);
+INSERT INTO `user` (`name`, `hashed_password`, `email`, `full_name`, `email_confirmed`, `is_paid`, `stripe_plan_id`)
+     VALUES ('admin', '9bbdccf408a2420e20fcd157c6315d5f77427c64', 'admin@example.com', 'Site Admin', 1, 1, 'mltshp-double');
 
 INSERT INTO `shake` (`user_id`, `type`, `name`) VALUES (1, 'user', 'Best of MLTSHP');
 INSERT INTO `shake` (`user_id`, `type`) VALUES (2, 'user');

--- a/setup/dev/mysql-conf.d/mltshp.cnf
+++ b/setup/dev/mysql-conf.d/mltshp.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+default_authentication_plugin=mysql_native_password

--- a/setup/dev/nginx.conf
+++ b/setup/dev/nginx.conf
@@ -130,7 +130,17 @@ http {
             upload_cleanup 400 404 499 500-505;
         }
 
-        location ~* ^/s3/((?:originals|webm|mp4|smalls|thumbs|account)/[a-zA-Z0-9]+)(.*) {
+        location ~* ^/s3/((?:account)/\d+/[a-zA-Z0-9-]+\.jpg) {
+            set $download_url http://mltshp-dev.fakes3:8000/$1;
+            proxy_hide_header Content-Disposition;
+            proxy_hide_header Content-Type;
+            proxy_set_header X-Rewrite-URL $download_url;
+            proxy_max_temp_file_size 0;
+            proxy_pass $download_url;
+            proxy_pass_header Surrogate-Control;
+        }
+
+        location ~* ^/s3/((?:originals|webm|mp4|smalls|thumbs)/[a-zA-Z0-9]+)(.*) {
             internal;
 
             set $download_uri $1;


### PR DESCRIPTION
Changes recommended "mltshp.dev" to "mltshp.local", since the
.dev TLD is owned by Google and they enforce https for requests
to that TLD (in Chrome).