### PR TITLE
ffmpeg updates

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,10 @@ FROM ubuntu:16.04
 LABEL maintainer "brad@bradchoate.com"
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get -y update && apt-get install -y \
+RUN apt-get -y update && \
+    apt-get install software-properties-common python-software-properties && \
+    add-apt-repository -y ppa:jonathonf/ffmpeg-3 && \
+    apt-get install -y \
     supervisor \
     cron \
     libmysqlclient-dev \

--- a/tasks/transcode.py
+++ b/tasks/transcode.py
@@ -52,7 +52,7 @@ def gif_to_video(sourcefile_id, file_key, input_file, format):
                 options += " -vf scale=iw:-2"
 
     elif format == "webm":
-        options = "-c:v libvpx-vp9 -crf 23 -b:v 500K -acodec none"
+        options = "-c:v libvpx -auto-alt-ref 0 -crf 23 -b:v 500K -acodec none"
 
     output_file = input_file.replace(".gif", ".%s" % format)
 

--- a/tasks/transcode.py
+++ b/tasks/transcode.py
@@ -52,7 +52,7 @@ def gif_to_video(sourcefile_id, file_key, input_file, format):
                 options += " -vf scale=iw:-2"
 
     elif format == "webm":
-        options = "-c:v libvpx -auto-alt-ref 0 -crf 23 -b:v 500K -acodec none"
+        options = "-c:v libvpx -auto-alt-ref 0 -crf 23 -b:v 2M -acodec none"
 
     output_file = input_file.replace(".gif", ".%s" % format)
 


### PR DESCRIPTION
* Adds a new package repository for providing ffmpeg v3 binaries for Ubuntu 16.04.
* Changes transcode for webm to use the VP8 encoder (we were using VP9, but VP8 has broader device support) and adjusted the bitrate to be better for VP8.