### PR TITLE
aws_port should not be used for production links

### DIFF
--- a/lib/utilities.py
+++ b/lib/utilities.py
@@ -48,7 +48,7 @@ def parse_xml(xml_string):
     return undom(minidom.parseString(xml_string))
 
 
-def s3_authenticated_url(s3_key, s3_secret, bucket_name=None, file_path=None, 
+def s3_authenticated_url(s3_key, s3_secret, bucket_name=None, file_path=None,
                              seconds=3600):
     """
     Return S3 authenticated URL sans network access or phatty dependencies like boto.
@@ -64,10 +64,10 @@ def s3_authenticated_url(s3_key, s3_secret, bucket_name=None, file_path=None,
 
     if options.aws_host == "s3.amazonaws.com":
         url_prefix = "https://"
+        port = ""
     else:
         url_prefix = "http://"
-
-    port = options.aws_port and (":%d" % options.aws_port) or ""
+        port = options.aws_port and (":%d" % options.aws_port) or ""
 
     return "%s%s.%s%s/%s%s" % (
         url_prefix, bucket_name, options.aws_host, port,
@@ -80,15 +80,16 @@ def s3_url(file_path):
     """
     assert file_path
 
+    port = ""
     if options.aws_host == "s3.amazonaws.com":
         url_prefix = 'https://'
     else:
         url_prefix = 'http://'
+        if options.aws_port:
+            port = ":%d" % options.aws_port
 
     return "%s%s.%s%s/%s" % (
-        url_prefix, options.aws_bucket, options.aws_host,
-        (options.aws_port in (443, 80, None) and "" or (":%d" % options.aws_port)),
-        file_path)
+        url_prefix, options.aws_bucket, options.aws_host, port, file_path)
 
 
 def base36encode(number, alphabet='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'):
@@ -165,7 +166,7 @@ def pretty_date(time=False):
         if diff > 1:
             diff_string = "months"
         return "%s %s ago" % (str(diff), diff_string)
-    
+
     diff_string = "year"
     diff = day_diff/365
     if diff > 1:
@@ -243,7 +244,7 @@ def transform_to_square_thumbnail(file_path, size_constraint, destination):
     if img.mode != "RGB":
         img = img.convert("RGB")
     width, height = img.size
-    
+
     # if image is below size constraint, we just paste it on
     # and let any pieces that are above constraint just get clipped off.
     if width < size_constraint or height < size_constraint:

--- a/models/user.py
+++ b/models/user.py
@@ -257,8 +257,7 @@ hello@mltshp.com
                 else:
                     protocol = 'http:'
             if options.app_host == 'mltshp.com':
-                aws_url = "%s//%s.%s%s" % (protocol, options.aws_bucket, options.aws_host,
-                    options.aws_port in (443, 80, None) and "" or (":%d" % options.aws_port))
+                aws_url = "%s//%s.%s" % (protocol, options.aws_bucket, options.aws_host)
             else:
                 # must be running for development. use the /s3 alias
                 aws_url = "/s3"


### PR DESCRIPTION
aws_port configuration is to allow for local development with
a fake s3 service running on a non-standard port. For production,
code was written in a way to try to avoid using it, but in
some cases it was, and ended up emitting things like:

  http://mltshp-production.s3.amazonaws.com:443/

which is an invalid URL since it prescribes a http scheme but
tries to talk to port 443 which is for SSL.