### PR TITLE
Provide a means to update credit card info from settings page.

### DIFF
--- a/celeryconfig.example.py
+++ b/celeryconfig.example.py
@@ -3,6 +3,7 @@ CELERY_IMPORTS = ("tasks.timeline", "tasks.counts", "tasks.migration", "tasks.tr
 
 ## Result store settings.
 CELERY_RESULT_BACKEND = "rpc://"
+CELERY_RESULT_PERSISTENT = False
 
 ## Broker settings.
 BROKER_HOST = "rabbitmq"

--- a/models/payment_log.py
+++ b/models/payment_log.py
@@ -56,6 +56,6 @@ class PaymentLog(Model):
             return []
         if count <= 0:
             return []
-            
+
         return PaymentLog.where('user_id = %s AND status IN (%s, %s) ORDER BY id desc LIMIT %s',
              user_id, 'payment', 'credit', count)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ mock==1.0.1
 pyOpenSSL==16.2.0
 backports.ssl==0.0.9
 requests==2.13.0
-stripe==1.51.0
-newrelic==2.82.0.62
+stripe==1.82.1
 yoyo-migrations==5.0.5
 ffmpy==0.2.2

--- a/routes.py
+++ b/routes.py
@@ -200,6 +200,7 @@ routes = [
     (r"/account/welcome-to-mltshp", handlers.account.WelcomeToMltshp),
     (r"/account/membership", handlers.account.MembershipHandler),
     (r"/account/payment/cancel", handlers.account.PaymentCancelHandler),
+    (r"/account/payment/update", handlers.account.PaymentUpdateHandler),
     (r'/account/settings/resend-verification-email',
         handlers.account.ResendVerificationEmailHandler),
     (r'/account/image-request', handlers.account.RequestImageZipFileHandler),

--- a/templates/account/settings.html
+++ b/templates/account/settings.html
@@ -1,4 +1,29 @@
 {% extends "base.html" %}
+{% block included_scripts %}
+<script type="text/javascript" src="https://checkout.stripe.com/checkout.js" charset="utf-8"></script>
+<script type="text/javascript">
+$(document).ready(function() {
+  var updateCardDetails = StripeCheckout.configure({
+    key: '{{ stripe_public_key }}',
+    name: 'MLTSHP, Inc.',
+    image: '{{ static_url("images/apple-touch-icon.png") }}',
+    email: '{{ current_user_object.email }}',
+    panelLabel: 'Update Card Details',
+    token: function(token) {
+      // Use the token to create the charge with a server-side script.
+      // You can access the token ID with `token.id`
+      $('#update-token').val(token.id);
+      $('#update-card-details-form').submit();
+    }
+  });
+
+  $('#update-card-details-btn').click(function(e) {
+    e.preventDefault();
+    updateCardDetails.open();
+  });
+});
+</script>
+{% end %}
 
 {% block title %}Your Account Settings{% end %}
 
@@ -115,12 +140,24 @@
           <h3>Membership Status</h3>
           <div class="member-status-block-content">
             {% if user.is_paid %}
+
               {% if cancel_flag %}
               <h4>You have canceled your subscription, but it will remain active
                 until the end of your subscription term.</h4>
               <p>View the <a href="/account/membership">Membership</a> page if you would
                 like to resubscribe.</p>
               {% else %}
+
+              {% if updated_flag %}
+              <p>Thanks for updating your credit card information!</p>
+              {% else %}
+              {% if past_due %}
+              <p><strong>IMPORTANT</strong> — Your subscription is currently <strong>Past Due</strong>.
+              This means your billing information needs to be updated, or you have no
+              active credit card. Use the button below to update your credit card information.</p>
+              {% end %}
+              {% end %}
+
               <h4>Your Membership Plan: <a href="/account/membership">{{ plan_name }}</a></h4>
                 {% if user.stripe_plan_id == "mltshp-double" and user.stripe_plan_rate > 24 %}
               <p>You subscribe at a custom rate of ${{ user.stripe_plan_rate }}/year.
@@ -132,12 +169,33 @@
               <ol class="transaction-list">
                 {% for item in payments %}
                   <li>
-                    <span class="amount">{{item.transaction_amount}}</span>
-                    {% if item.status == 'credit' %}credited{% else %}received{% end %}
-                    on <span class="date">{{item.created_at.strftime("%B %d, %Y")}}</span>
+                    <span class="amount">{{item['transaction_amount']}}</span>
+                    {% if item['status'] == 'credit' %}credited{% else %}received{% end %}
+                    on <span class="date">{{item['created_at'].strftime("%B %d, %Y")}}</span>
                   </li>
                 {% end %}
               </ol>
+
+              {% if not cancel_flag %}
+              <p><hr></p>
+
+              <p><strong>Current Payment Source</strong><br>
+                {% if source_card_type and source_last_4 and source_expiration %}
+                  Card type: {{ source_card_type }}<br>
+                  Card ending in: {{ source_last_4 }}<br>
+                  Expiration date: {{ source_expiration }}
+                {% else %}
+                  <em>No card presently on file!</em>
+                {% end %}
+              </p>
+
+              <button id="update-card-details-btn" class="btn btn-secondary btn-shadow">Update Card Details</button>
+
+              <form id="update-card-details-form" action="/account/payment/update" method="POST">
+                {{ xsrf_form_html() }}
+                <input type="hidden" id="update-token" value="">
+              </form>
+              {% end %}
 
               {% if not cancel_flag %}
               <p>If you'd like to cancel your subscription <a href="/account/payment/cancel">you can do so here</a>.</p>


### PR DESCRIPTION
Allows a member to see and update their credit card info as stored on
Stripe (MLTSHP has no record of this info in our own database, and we
can only access the metadata, along with the last 4 digits. Updating it
requires Stripe Checkout to provide the user experience.).

For failed invoicing, we will allow Stripe to notify the user by email
and they will provide a link to this account page where they can update
their credit card information.