### PR TITLE
For account history, show success/fail/refund status

### DIFF
--- a/templates/account/settings.html
+++ b/templates/account/settings.html
@@ -165,13 +165,22 @@ $(document).ready(function() {
                 {% end %}
               {% end %}
 
-              <p>Your last 3 payments or credits:</p>
+              <p>Your recent payment history:</p>
               <ol class="transaction-list">
                 {% for item in payments %}
                   <li>
+                    {% if item['is_refund'] %}
                     <span class="amount">{{item['transaction_amount']}}</span>
-                    {% if item['status'] == 'credit' %}credited{% else %}received{% end %}
+                    charged; refunded <span class="amount">{{item['refund_amount']}}</span>
                     on <span class="date">{{item['created_at'].strftime("%B %d, %Y")}}</span>
+                    {% else %}
+                    <span class="amount">{{item['transaction_amount']}}</span>
+                    {% if item['status'] == 'credit' %}credited{% else %}charged{% end %}
+                    on <span class="date">{{item['created_at'].strftime("%B %d, %Y")}}</span>
+                    {% if item['is_pending'] %} (pending){% end %}
+                    {% if item['is_failed'] %} (failed){% end %}
+                    {% if item['is_success'] %} &#128077;{% end %}
+                    {% end %}
                   </li>
                 {% end %}
               </ol>

--- a/test/functional/payments_tests.py
+++ b/test/functional/payments_tests.py
@@ -29,7 +29,7 @@ class PaymentTests(test.base.BaseAsyncTestCase):
         self.user.is_paid = 1
         self.user.save()
         response = self.fetch_url('/account/settings')
-        self.assertTrue(response.body.find('Your last 3 payments or credits:') > -1)
+        self.assertTrue(response.body.find('Your recent payment history:') > -1)
 
     def test_subcription_webhook_sets_paid_status(self):
         self.user.stripe_customer_id = "cus_AHgKQnggJErzEA"


### PR DESCRIPTION
Excluding failed charges truncated list excluding successful
charges; we should just show failures too so it is more obvious
when a problem is occurring.