### PR TITLE
Updating privacy policy

### DIFF
--- a/templates/account/announcement-tou.html
+++ b/templates/account/announcement-tou.html
@@ -6,11 +6,14 @@
   <div class="content content-narrow">
     <div class="tou-notice-page">
       <p>
-        Hi everyone and welcome to MLTSHP! We have an updated Terms of Use document everyone who signed up before
+        Hi everyone and welcome to MLTSHP! We have an updated Terms of Use / Privacy Policy document everyone
         today needs to agree to. Nothing that different from before, but important because <em>Legal Reasons</em>.
+        We wanted to update it to be more up-front and open about the services we utilize to make the magic
+        that is MLTSHP.
       </p>
       <p>
-        By clicking this button, you agree to <a href="/terms-of-use" target="_blank">the terms listed on this page</a>.
+        By clicking this button, you agree to <a href="/terms-of-use" target="_blank">the terms listed on this page</a>
+        and our <a href="/code-of-conduct" target="_blank">Code of Conduct</a>.
       </p>
       <div class="tou-agree">
         <a class="btn btn-primary btn-shadow" href="/account/announcement/tou?agree=you-bet">I Agree</a>

--- a/templates/misc/terms-of-use.html
+++ b/templates/misc/terms-of-use.html
@@ -32,8 +32,6 @@
     <li>respond to claims that the content of any material on our system violates the rights of others.</li>
     </ol>
 
-    <p>We will aggregate user information and perform statistical analyses of the collective characteristics and behavior of our members and visitors, to measure overall demographics and interests regarding specific areas of our domain and to analyze how and where to use our resources. We may share general demographic and interest information with third parties, but such aggregate information is not personally identifiable. We may also use the aggregate data collected to inform our sponsors as to the number of people who have seen and &ldquo;clicked&rdquo; on their advertisement. In addition, we may compile and disclose aggregate information about our users for promotional or other purposes. For example, we might want to disclose that a certain percentage of our users are located within a particular geographic area or fall within a particular age range.</p>
-
     <p>We use your PI in various ways to provide access to our website and service. We use PI to enhance your site experience in the following ways:</p>
 
     <p>Complete a Transaction: We use PI to complete a transaction requested by you. We also may use this information to keep track of your purchases or notify you of any product or service that we believe may be of interest to you.</p>
@@ -44,19 +42,27 @@
 
     <p>Social Media: We may use PI to connect you with external applications, such as social media web sites or platforms.</p>
 
-    <p>We also collect non-personally identifiable information when you use the site. </p>
+    <p>We also collect non-personally identifiable information when you use the site.</p>
 
     <p>We use both session cookies and persistent cookies. Cookies help us determine how long users view particular content, which particular content (e.g. advertising) users view, which content or sites users link to, and which services members and visitors use. Persistent cookies are used if you choose to enable the auto-login feature. These cookies are randomly generated and uniquely assigned to each user. They are not associated with any personally identifiable information such as name or password. Session cookies help us keep track of when a person is logged in. Once a user is logged in, session cookies allow us to personalize information on the Site for them.</p>
 
-    <p>We collect user IP addresses. We use your IP address to help diagnose problems with our server and to administer the site. Your IP address is also used to gather broad demographic information such as geographic distribution of our members. We do not intentionally link your IP address to your personally identifiable information.</p>
+    <p>We do not collect or log user IP addresses.</p>
 
-    <p>Analytics Tools: We use analytics tools and other third party technologies, such as Google Analytics, to collect non-personal information in the form of various usage and user metrics when you use our Site. These tools and technologies collect and analyze certain types of information, including cookies, IP addresses, device and software identifiers, referring and exit URLs, onsite behavior and usage information, feature use metrics and statistics, usage and purchase history, MAC Address, mobile unique device ID, and other similar information. Google has additional information available about <a href="https://www.google.com/policies/privacy/partners/">how they use this information</a>.</p>
+    <p><strong>Analytics Tools: Google Analytics.</strong> We use Google Analytics to collect non-personal information in the form of various usage and user metrics when you use our Site. These tools and technologies collect and analyze certain types of information, including cookies, device and software identifiers, referring and exit URLs, onsite behavior and usage information, feature use metrics and statistics, and other similar information. Google has additional information available about <a href="https://www.google.com/policies/privacy/partners/">how they use this information</a>. We instruct Google Analytics to anonymize IP addresses, so your IP address will not be stored as a result.</p>
 
-    <p>Third Party Service Providers: Paid subscriptions are handled by a third party service provider, Stripe, pursuant to its <a href="https://stripe.com/us/legal">terms of service</a>. Any information you provide to Stripe will be maintained in accordance with its policies, and not ours. </p>
+    <p><strong>Third Party Service Providers: Stripe.</strong> Paid subscriptions are handled by a third party service provider, Stripe, pursuant to its <a href="https://stripe.com/us/legal">terms of service</a>. Any information you provide to Stripe will be maintained in accordance with its policies, and not ours. We do provide Stripe with the email address used for MLTSHP, since it is necessary for email communications in the event of a payment failure.</p>
+
+    <p><strong>Third Party Service Providers: YouTube.com, Flickr.com, Vimeo.com.</strong> We support posting content from several third-party sites. When viewing their embeded media, your browser is issuing requests to those services for that media. In doing so, your IP address may be shared with these services. If you would like to know more about their privacy policies, you can view them individually: <a href="https://support.google.com/youtube/answer/7671399?hl=en">YouTube.com</a>, <a href="https://www.smugmug.com/about/privacy-flickr">Flickr.com</a>, <a href="https://vimeo.com/privacy">Vimeo.com</a>.</p>
+
+    <p><strong>Third Party Service Providers: Cloudflare.com.</strong> MLTSHP utilizes Cloudflare for optimizing and delivering our content worldwide. <a href="https://www.cloudflare.com/security-policy/">Cloudflare’s privacy policy</a>.</p>
+
+    <p><strong>Third Party Service Providers: Linode.com.</strong> MLTSHP services operate on Linode servers. <a href="https://www.linode.com/privacy">Linode’s privacy policy.</a></p>
+
+    <p><strong>Third Party Service Providers: Amazon AWS.</strong> We utilize Amazon’s AWS and S3 services for storing images (profile pictures, as well as uploaded photos, GIFs, and videos. <a href="https://aws.amazon.com/privacy/">Amazon’s privacy policy.</a></p>
 
     <p>2. <u>FEES</u></p>
 
-    <p>MLTSHP.com offers a range of subscription plans for its Services (each, a &ldquo;Plan&rdquo;). 
+    <p>MLTSHP.com offers a range of subscription plans for its Services (each, a &ldquo;Plan&rdquo;).
     You will select your Plan as part of your registration for the Services. Each subscription period for a Plan is one year and billed at the beginning of your subscription. To view the specific details of your Plan, including pricing information and the end date of your subscription period, login to your account on MLTSHP.com and click the &ldquo;Account&rdquo; page, or contact us at <a href="mailto:hello@mltshp.com">hello@mltshp.com</a>.</p>
 
     <p><strong>Payment of fees:</strong><br />


### PR DESCRIPTION
Clearly documents our third-party service usage (and links to their
respective policy documentation).

Revise statement about collecting IP addresses (MLTSHP never has).

Cleared up language around use of analytics (we do not share with
third-parties; we instruct Google to not store IP addresses).