### PR TITLE
Improving interaction for membership form for re-subscribing

### DIFF
--- a/templates/account/membership.html
+++ b/templates/account/membership.html
@@ -20,15 +20,13 @@ $(document).ready(function() {
   $('#subscribe-button-single-scoop').click(function(e) {
     e.preventDefault();
     $('#subscribe-plan-id').val('mltshp-single');
-    {% if stripe_customer_id == None %}
+
     // Open Checkout with further options
     subscribeHandler.open({
       description: '1 Year ($3.00)',
-      amount: 300
+      amount: 300,
+      zipCode: true
     });
-    {% else %}
-    $('#membership-form').submit();
-    {% end %}
     return false;
   });
 
@@ -48,15 +46,12 @@ $(document).ready(function() {
     }
     $('#subscribe-plan-quantity').val(quantity.toString());
 
-    {% if stripe_customer_id == None %}
     // Open Checkout with further options
     subscribeHandler.open({
       description: '1 Year ($' + quantity.toString() + '.00)',
-      amount: quantity * 100
+      amount: quantity * 100,
+      zipCode: true
     });
-    {% else %}
-    $('#membership-form').submit();
-    {% end %}
     return false;
   });
 

--- a/templates/account/settings.html
+++ b/templates/account/settings.html
@@ -210,11 +210,18 @@ $(document).ready(function() {
               <p>If you'd like to cancel your subscription <a href="/account/payment/cancel">you can do so here</a>.</p>
               {% end %}
             {% else %}
+              {% if user.stripe_customer_id %}
+              <p>
+                You have no active MLTSHP subscription. <a href="/account/membership">Click here to re-subscribe</a>
+                if you'd like to support MLTSHP!
+              </p>
+              {% else %}
               <p>
                 You are currently using a free account. If you'd like
                 to support MLTSHP and get some nifty new benefits you can
                 <a href="/account/membership">upgrade to a paid account</a>.
               </p>
+              {% end %}
 
               {% if promotions and not site_is_readonly %}
                 <p>


### PR DESCRIPTION
Always presents the Stripe UI for entering credit card information
whenever the membership buttons are used. This gives the user the
chance to verify and/or update their payment information at checkout
if it is needed. Previously, we were bypassing this step when a
subscription was already active but this has led to issues with
members who have an invalid card and as a result cannot resubscribe.

Also cleaned up the copy for the account settings page for members
who no longer have an active subscription.