### PR TITLE
Updates for handling attribution for deleted sharedfiles

### DIFF
--- a/handlers/image.py
+++ b/handlers/image.py
@@ -314,7 +314,7 @@ class ShowRawHandler(BaseHandler):
 
         # piece together headers to be picked up by nginx to proxy file from S3
         self.set_header("Content-Type", sharedfile.content_type)
-        self.set_header("Surrogate-Control", "max-age=86400")        
+        self.set_header("Surrogate-Control", "max-age=86400")
         self.set_header("Connection", "close")
         return
 
@@ -521,8 +521,8 @@ class UnlikeHandler(BaseHandler):
                 return self.redirect('/p/%s' % (sharedfile_key))
 
         #Attempt to remove favorites for the parent and original
-        original_sf = sharedfile.original()
-        parent_sf = sharedfile.parent()
+        original_sf = sharedfile.original(include_deleted=True)
+        parent_sf = sharedfile.parent(include_deleted=True)
         if original_sf:
             user.remove_favorite(original_sf)
         if parent_sf and parent_sf.user_id != original_sf.user_id:

--- a/models/sharedfile.py
+++ b/models/sharedfile.py
@@ -366,21 +366,29 @@ class Sharedfile(ModelQueryCache, Model):
         """
         return user.User.get("id = %s and deleted=0", self.user_id)
 
-    def parent(self):
+    def parent(self, include_deleted=False):
         """
         Returns the parent object if it's set, otherwise returns None.
         """
         if not bool(self.parent_id):
             return None
-        return self.get("id = %s and deleted=0", self.parent_id)
+        if include_deleted:
+            deleted_clause = ''
+        else:
+            deleted_clause = ' and deleted=0'
+        return self.get("id = %s" + deleted_clause, self.parent_id)
 
-    def original(self):
+    def original(self, include_deleted=False):
         """
         Returns the original object if it's set, otherwise returns None.
         """
         if not bool(self.original_id):
             return None
-        return self.get("id = %s and deleted=0", self.original_id)
+        if include_deleted:
+            deleted_clause = ''
+        else:
+            deleted_clause = ' and deleted=0'
+        return self.get("id = %s" + deleted_clause, self.original_id)
 
     def parent_user(self):
         """

--- a/models/sharedfile.py
+++ b/models/sharedfile.py
@@ -322,7 +322,7 @@ class Sharedfile(ModelQueryCache, Model):
         """
         if options.readonly:
             return False
-        ssf = shakesharedfile.Shakesharedfile.get("shake_id = %s and sharedfile_id = %s", from_shake.id, self.id)
+        ssf = shakesharedfile.Shakesharedfile.get("shake_id = %s and sharedfile_id = %s and deleted=0", from_shake.id, self.id)
         if not ssf:
             return False
         ssf.deleted = 1
@@ -338,7 +338,7 @@ class Sharedfile(ModelQueryCache, Model):
         """
         if options.readonly:
             return False
-        ssf = shakesharedfile.Shakesharedfile.get("shake_id = %s and sharedfile_id = %s", to_shake.id, self.id)
+        ssf = shakesharedfile.Shakesharedfile.get("shake_id = %s and sharedfile_id = %s and deleted=0", to_shake.id, self.id)
         if not ssf:
             ssf = shakesharedfile.Shakesharedfile(shake_id=to_shake.id, sharedfile_id=self.id)
         ssf.deleted = 0
@@ -364,7 +364,7 @@ class Sharedfile(ModelQueryCache, Model):
         """
         Returns sharedfile's user.
         """
-        return user.User.get("id = %s", self.user_id)
+        return user.User.get("id = %s and deleted=0", self.user_id)
 
     def parent(self):
         """
@@ -372,7 +372,7 @@ class Sharedfile(ModelQueryCache, Model):
         """
         if not bool(self.parent_id):
             return None
-        return self.get("id = %s", self.parent_id)
+        return self.get("id = %s and deleted=0", self.parent_id)
 
     def original(self):
         """
@@ -380,7 +380,7 @@ class Sharedfile(ModelQueryCache, Model):
         """
         if not bool(self.original_id):
             return None
-        return self.get("id = %s", self.original_id)
+        return self.get("id = %s and deleted=0", self.original_id)
 
     def parent_user(self):
         """

--- a/templates/uimodules/image.html
+++ b/templates/uimodules/image.html
@@ -130,15 +130,19 @@
                 </div>
             {% end %}
         </div>
-        {% if sharedfile.original() %}
+        {% if sharedfile.original() or sharedfile.original_id > 0 %}
             <div class="originally-posted-by">
                 {{ original_user = sharedfile.original_user()}}
                 originally
+                {% if original_user %}
                 <a class="the-post" href="/p/{{sharedfile.original().share_key}}">posted</a> by
                 <a class="avatar--link" href="/user/{{original_user.name}}">
                     <img class="avatar--img" valign="bottom" width="20" height="20" src="{{original_user.profile_image_url()}}" alt="">
                 </a>
                 <a class="user-name" href="/user/{{original_user.name}}">{{ original_user.name }}</a>
+                {% else %}
+                posted by someone else
+                {% end %}
             </div>
         {% end %}
         <div class="inline-meta">


### PR DESCRIPTION
Do not expose soft-deleted sharedfiles when checking for original
Display "someone else" as the attribution if the original post was deleted

fixes #380