### PR TITLE
removing unused GoogleAnalyticsObject

### DIFF
--- a/static/50x.html
+++ b/static/50x.html
@@ -48,13 +48,5 @@
             </p>
         </footer>
     </div>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-96185399-1', 'auto');
-        ga('send', 'pageview');
-    </script>
 </body>
 </html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -170,14 +170,5 @@
     <script type="text/javascript" charset="utf-8" src="{{ static_url("js/paging_keys.js") }}"></script>
     {% block included_scripts %}
     {% end %}
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-96185399-1', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
 </body>
 </html>

--- a/templates/tools/base-sign-in.html
+++ b/templates/tools/base-sign-in.html
@@ -29,14 +29,5 @@
 
     <script type="text/javascript" charset="utf-8" src="{{ static_url("js/jquery-min-1.4.2.js") }}"></script>
     {% block included_scripts %}{% end %}
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-96185399-1', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
   </body>
 </html>

--- a/templates/tools/base.html
+++ b/templates/tools/base.html
@@ -33,14 +33,5 @@
     <script type="text/javascript" charset="utf-8" src="{{ static_url("js/jquery-min-1.4.2.js") }}"></script>
     <script type="text/javascript" src="{{ static_url("js/tools.js")}}" charset="utf-8"></script>
     {% block included_scripts %}{% end %}
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-96185399-1', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
   </body>
 </html>


### PR DESCRIPTION
Based on a brief discussion in the #technology channel of the Slack, GoogleAnalyticsObject isn't used and can be safely removed.