### PR TITLE
Fixes issues where credit card is updated for existing subscriber

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ sass-watch:
 run: sass-compile
 	docker-compose up -d
 
+stop:
+	docker-compose down
+
 build:
 	docker build -t mltshp/mltshp-web:latest .
 

--- a/templates/account/settings.html
+++ b/templates/account/settings.html
@@ -215,6 +215,26 @@ $(document).ready(function() {
                 You have no active MLTSHP subscription. <a href="/account/membership">Click here to re-subscribe</a>
                 if you'd like to support MLTSHP!
               </p>
+
+              <p><hr></p>
+
+              <p><strong>Current Payment Source</strong><br>
+                {% if source_card_type and source_last_4 and source_expiration %}
+                  Card type: {{ source_card_type }}<br>
+                  Card ending in: {{ source_last_4 }}<br>
+                  Expiration date: {{ source_expiration }}
+                {% else %}
+                  <em>No card presently on file!</em>
+                {% end %}
+              </p>
+
+              <button id="update-card-details-btn" class="btn btn-secondary btn-shadow">Update Card Details</button>
+
+              <form id="update-card-details-form" action="/account/payment/update" method="POST">
+                {{ xsrf_form_html() }}
+                <input name="token" type="hidden" id="update-token" value="">
+              </form>
+
               {% else %}
               <p>
                 You are currently using a free account. If you'd like


### PR DESCRIPTION
Properly associates any new token with the Stripe customer object
during the membership request.

Also displays an option to update credit card information if
the MLTSHP user has a Stripe customer record but does not have
an active subscription.

Fixes #528