### PR TITLE
Prevent upload via plugin when user exceeds limits

### DIFF
--- a/handlers/tools.py
+++ b/handlers/tools.py
@@ -70,11 +70,13 @@ class PickerPopupHandler(BaseHandler):
         is_video = False
 
         shakes = current_user.shakes(include_managed=True)
+        can_upload_this_month = current_user.can_upload_this_month()
 
         #replace plus signs with %20's
         return self.render("tools/picker.html", file_name=file_name, width="", height="", \
             url=parsed_url.scheme + "://" + parsed_url.netloc + parsed_url.path + parsed_url_query, \
-            source_url=source_url, description='', is_video=is_video, shakes=shakes)
+            source_url=source_url, description='', is_video=is_video, shakes=shakes,
+            can_upload_this_month=can_upload_this_month)
 
     @tornado.web.authenticated
     @tornado.web.asynchronous

--- a/static/sass/areas/_tools.scss
+++ b/static/sass/areas/_tools.scss
@@ -130,4 +130,12 @@
         font-size: 26px;
         font-weight: bold;
     }
+
+    .picker-content .email-unverified h2,
+    .picker-content .over-upload-limit h2 {
+        color: $color-mltshp-pink;
+        font-size: 24px;
+        text-align: center;
+        height: 1.5em;
+    }
 }

--- a/templates/tools/picker.html
+++ b/templates/tools/picker.html
@@ -1,7 +1,15 @@
 {% extends 'tools/base.html' %}
 
 {% block main %}
-    <div class="picker-content">
+<div class="picker-content">
+    {% if current_user and current_user_object and current_user_object.email_confirmed != 1 %}
+    <div class="email-unverified">
+      <h2>Email Unconfirmed</h2>
+      <h3>In order to post, you have to confirm your email address first. Check your email for the confirmation
+          link. Visit your <a href="/account/settings" target="_blank">account settings</a> if you need it re-sent.</h3>
+    </div>
+    {% else %}
+    {% if can_upload_this_month %}
       <form class="fun-form fun-form-stacked tools-fun-form" method="post" action="/tools/p">
 
         <div class="field tools-field-title">
@@ -56,4 +64,11 @@
     <div class="picker-image">
       <img src="{{url}}" alt="">
     </div>
+    {% else %}
+    <div class="over-upload-limit">
+      <h2>Upload account limit</h2>
+      <h3>You've reached the limit on the number of megs you can upload in a month. That limit is 300 megabytes. If you'd like to <a href="/account/membership" target="_blank">become a Double Scoop member</a>! It's just $2/month.</h3>
+    </div>
+    {% end %}
+    {% end %}
 {% end %}


### PR DESCRIPTION
The separate code path for sideloading allowed for posting images even
after the a single scoop user exceeded their monthly quota. This also
allowed for uploading without a confirmed email address. Both of these
issues have been addressed.

Fixes #534