### PR TITLE
Applying autocomplete, autocorrect attributes

### DIFF
--- a/templates/account/create.html
+++ b/templates/account/create.html
@@ -20,7 +20,7 @@
         <div class="field">
           <label for="name">Username:</label>
           <div class="field-input">
-            <input class="input-text" type="text" name="name" value="{{xhtml_escape(name)}}" autocapitalize="none">
+            <input class="input-text" type="text" name="name" value="{{xhtml_escape(name)}}" autocapitalize="none" autocomplete="username">
             {% if errors.name %}
             <div class="error">
               <span class="error-text">
@@ -37,7 +37,7 @@
         <div class="field">
           <label for="password">Password:</label>
           <div class="field-input">
-            <input class="input-text" type="password" name="password" >
+            <input class="input-text" type="password" name="password" autocomplete="new-password">
             {% if errors.password %}
             <div class="error">
               <span class="error-text">
@@ -51,7 +51,7 @@
         <div class="field">
           <label for="password_again">Password, again:</label>
           <div class="field-input">
-            <input class="input-text" type="password" name="password_again" >
+            <input class="input-text" type="password" name="password_again" autocomplete="new-password">
           </div>
           <div class="field-help">
             Enter the same password as above for verification.
@@ -61,7 +61,7 @@
         <div class="field">
           <label>Email:</label>
           <div class="field-input">
-            <input class="input-text" type="email" name="email" value="{{xhtml_escape(email)}}">
+            <input class="input-text" type="email" name="email" value="{{xhtml_escape(email)}}" autocomplete="email">
             {% if errors.email %}
             <div class="error">
               <span class="error-text">

--- a/templates/account/forgot-password.html
+++ b/templates/account/forgot-password.html
@@ -16,7 +16,7 @@
         <div class="field">
           <label for="email">Email Address:</label>
           <div class="field-input">
-            <input class="input-text" type="text" name="email" value="{{email}}">
+            <input class="input-text" type="text" name="email" value="{{email}}" autocomplete="email">
             {% if errors.email %}
             <div class="error">
               <span class="error-text">

--- a/templates/account/index.html
+++ b/templates/account/index.html
@@ -25,10 +25,10 @@
 
       <div class="sidebar-search-block fun-form">
         <form method="GET" action="/search">
-          <input type="hidden" name="context" value="{% if user.id == current_user_obj.id %}in:mine{% else %}from:{{escape(user.name)}}{% end %}">
+          <input type="hidden" name="context" value="{% if user.id == current_user_obj.id %}in:mine{% else %}from:{{escape(user.name)}}{% end %}" autocomplete="off">
           <div class="field">
             <div class="field-input">
-              <input type="search" class="input-text" name="q" placeholder="{% if user.id == current_user_obj.id %}Search your shake!{% else %}Search posts by this user!{% end %}">
+              <input type="search" class="input-text" name="q" placeholder="{% if user.id == current_user_obj.id %}Search your shake!{% else %}Search posts by this user!{% end %}" autocorrect="off">
             </div>
           </div>
         </form>

--- a/templates/account/likes.html
+++ b/templates/account/likes.html
@@ -22,7 +22,7 @@
           <input type="hidden" name="context" value="in:likes">
           <div class="field">
             <div class="field-input">
-              <input type="search" class="input-text" name="q" placeholder="Search your favorites!">
+              <input type="search" class="input-text" name="q" placeholder="Search your favorites!" autocorrect="off">
             </div>
           </div>
         </form>

--- a/templates/account/reset-password.html
+++ b/templates/account/reset-password.html
@@ -17,7 +17,7 @@
         <div class="field">
           <label for="password">Password:</label>
           <div class="field-input">
-            <input class="input-text" type="password" name="password" >
+            <input class="input-text" type="password" name="password" autocomplete="new-password">
             {% if errors.password %}
             <div class="error">
               <span class="error-text">
@@ -31,7 +31,7 @@
         <div class="field">
           <label>Password, again:</label>
           <div class="field-input">
-            <input class="input-text" type="password" name="password_again" >
+            <input class="input-text" type="password" name="password_again" autocomplete="new-password">
           </div>
           <div class="field-help">
             Enter the same password as above for verification.

--- a/templates/account/settings-profile.html
+++ b/templates/account/settings-profile.html
@@ -48,7 +48,7 @@
             <div class="field">
               <label for="full_name">Full Name</label>
               <div class="field-input">
-                <input type="text" class="input-text" name="full_name" maxlength="100" value="{{escape(user.full_name)}}"{% if site_is_readonly or user.email_confirmed == 0 %} disabled="disabled"{% end %}>
+                <input type="text" class="input-text" name="full_name" maxlength="100" value="{{escape(user.full_name)}}"{% if site_is_readonly or user.email_confirmed == 0 %} disabled="disabled"{% end %} autocomplete="name">
               </div>
               {% if errors.full_name %}
               <div class="error">
@@ -79,7 +79,7 @@
             <div class="field">
               <label for="website">Website</label>
               <div class="field-input">
-                <input type="text" class="input-text" name="website" maxlength="255" value="{{escape(user.website)}}"{% if site_is_readonly or user.email_confirmed == 0 %} disabled="disabled"{% end %}>
+                <input type="text" class="input-text" name="website" maxlength="255" value="{{escape(user.website)}}"{% if site_is_readonly or user.email_confirmed == 0 %} disabled="disabled"{% end %} autocomplete="url">
               </div>
               {% if errors.website %}
               <div class="error">

--- a/templates/account/settings.html
+++ b/templates/account/settings.html
@@ -61,7 +61,7 @@ $(document).ready(function() {
           <div class="field">
             <label for="email">Email</label>
             <div class="field-input more">
-              <input type="text" name="email" class="input-text" value="{{escape(user.email)}}"{% if site_is_readonly %} disabled="disabled"{% end %}>
+              <input type="text" name="email" class="input-text" value="{{escape(user.email)}}"{% if site_is_readonly %} disabled="disabled"{% end %} autocomplete="email">
               {% if errors.email %}
               <div class="error">
                 <span class="error-text">

--- a/templates/account/sign-in.html
+++ b/templates/account/sign-in.html
@@ -20,7 +20,7 @@
           <label for="name">Username:</label>
           <div class="field-input">
             <input class="input-text" type="text" name="name" value="{{name}}"
-            autocorrect="off" autocapitalize="none">
+            autocorrect="off" autocapitalize="none" autocomplete="username">
             {% if errors.name %}
             <div class="error">
               <span class="error-text">
@@ -33,7 +33,7 @@
         <div class="field">
           <label for="password">Password:</label>
           <div class="field-input">
-            <input class="input-text" type="password" name="password" >
+            <input class="input-text" type="password" name="password"  autocomplete="current-password">
           </div>
         </div>
         <div class="field field-submit">

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -49,7 +49,7 @@
         <input type="hidden" name="context" value="in:friends">
         <div class="field">
           <div class="field-input">
-            <input type="search" class="input-text" name="q" placeholder="Search your friend shake!">
+            <input type="search" class="input-text" name="q" placeholder="Search your friend shake!" autocorrect="off">
           </div>
         </div>
       </form>

--- a/templates/incoming/index.html
+++ b/templates/incoming/index.html
@@ -20,7 +20,7 @@
         <form method="GET" action="/search">
           <div class="field">
             <div class="field-input">
-              <input type="search" class="input-text" name="q" placeholder="Search everything!">
+              <input type="search" class="input-text" name="q" placeholder="Search everything!" autocorrect="off">
             </div>
           </div>
         </form>

--- a/templates/popular/index.html
+++ b/templates/popular/index.html
@@ -29,7 +29,7 @@
         <input type="hidden" name="context" value="in:popular">
         <div class="field">
           <div class="field-input">
-            <input type="search" class="input-text" name="q" placeholder="Search the popular shake!">
+            <input type="search" class="input-text" name="q" placeholder="Search the popular shake!" autocorrect="off">
           </div>
         </div>
       </form>

--- a/templates/search/_sidebar.html
+++ b/templates/search/_sidebar.html
@@ -4,7 +4,7 @@
     <form method="GET" action="/search">
       <div class="field">
         <div class="field-input">
-          <input {% if len(sharedfiles) == 0 %}autofocus {% end %}class="input-text" type="search" placeholder="Search" name="q" value="{{xhtml_escape(q)}}" autocapitalize="none">
+          <input {% if len(sharedfiles) == 0 %}autofocus {% end %}class="input-text" type="search" placeholder="Search" name="q" value="{{xhtml_escape(q)}}" autocorrect="off">
           {% if errors.q %}
           <div class="error">
             <span class="error-text">

--- a/templates/shakes/_sidebar.html
+++ b/templates/shakes/_sidebar.html
@@ -125,7 +125,7 @@
       <input type="hidden" name="context" value="in:{{escape(shake.name)}}">
       <div class="field">
         <div class="field-input">
-          <input type="search" class="input-text" name="q" placeholder="Search this shake!">
+          <input type="search" class="input-text" name="q" placeholder="Search this shake!" autocorrect="off">
         </div>
       </div>
     </form>

--- a/templates/tools/sign-in.html
+++ b/templates/tools/sign-in.html
@@ -11,7 +11,7 @@
           <label>Username:</label>
           <div class="field-input">
             <input class="input-text" type="text" name="name" value="{{name}}"
-             autocorrect="off" autocapitalize="none">
+             autocorrect="off" autocapitalize="none" autocomplete="username">
             {% if errors.name %}
             <div class="error">
               <span class="error-text">
@@ -24,7 +24,7 @@
         <div class="field">
           <label>Password:</label>
           <div class="field-input">
-            <input class="input-text" type="password" name="password" >
+            <input class="input-text" type="password" name="password" autocomplete="new-password">
           </div>
         </div>
         <div class="field field-submit">


### PR DESCRIPTION
For now, assigning these to generally disable 'autocorrect'
for the 'search' input fields, and using appropriate 'autocomplete'
values for certain inputs (username, password, name, etc.) to help form
filling features of browsers/extensions.

Fixes #551