### PR TITLE
Append `| MLTSHP` to every page’s <title>

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>{% block title %}{% end %} &mdash; MLTSHP</title>
+    <title>{% block title %}{% end %} | MLTSHP</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="search" type="application/opensearchdescription+xml" href="{{ static_url("opensearch.xml") }}" title="mltshp">
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>{% block title%}mltshp{% end %}</title>
+    <title>{% block title %}{% end %} &mdash; MLTSHP</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="search" type="application/opensearchdescription+xml" href="{{ static_url("opensearch.xml") }}" title="mltshp">
 

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -1,9 +1,8 @@
 {% extends "base.html" %}
 
 {% block title %}
-{% if sharedfiles %}
-  {{sharedfiles[0].created_at.strftime("%B")}}
-{% end %}
+  {% if sharedfiles %}{{sharedfiles[0].created_at.strftime("%B")}} &ndash; {% end %}
+  Friend Shake
 {% end %}
 
 {% block main %}

--- a/templates/home/not-logged-in.html
+++ b/templates/home/not-logged-in.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}
-  mltshp
-{% end %}
+{% block title %}Welcome!{% end %}
 
 {% block main %}
 

--- a/templates/incoming/index.html
+++ b/templates/incoming/index.html
@@ -1,5 +1,7 @@
 {%extends "base.html" %}
 
+{% block title %}Incoming!!!{% end %}
+
 {% block main %}
   <div class="content content-with-sidebar content-incoming">
     <div class="incoming-header">

--- a/templates/tools/base-sign-in.html
+++ b/templates/tools/base-sign-in.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>{% block title%}mltshp{% end %}</title>
+    <title>{% block title %}Sign In{% end %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link type="text/css" rel="stylesheet" href="{{ static_url("css/main.css") }}">


### PR DESCRIPTION
- Fix the main / Friend Shake just having the current month as a title.
- Add some fallbacks where there weren’t individual page titles.

<img width="236" alt="Empty Friend Shake" src="https://user-images.githubusercontent.com/435/67721108-227fc200-f9ac-11e9-8bfc-be9ca4f165ba.png">

<img width="236" alt="Friend Shake with current month" src="https://user-images.githubusercontent.com/435/67721112-24e21c00-f9ac-11e9-9719-59db6e29b817.png">
