### PR TITLE
faq.html - describe membership permissions

### DIFF
--- a/templates/misc/faq.html
+++ b/templates/misc/faq.html
@@ -27,16 +27,24 @@
       <ul>
         <li>Non-members can see the Popular page and individual posts.</li>
         <li>
-          Members at the Single Scoop level ($3 per year) can save, like, and comment on their
-          friends' images, and upload their own image and video posts, up to a monthly upload
-          limit of 300MB. It's a great way to check out the site.
+          The Single Scoop level ($3 per year) is a great way to check out the site. Members can:
+            <ul>
+                <li>Post images and videos to their own shakes and to group shakes, up to a 
+                    monthly upload limit of 300MB for images and animated GIFs.</li>
+                <li>Follow their friends' shakes and group shakes.</li>
+                <li>Save, like, and comment on any posts.</li>
+            </ul>
         </li>
         <li>
-          Members at the Double Scoop level ($24 per year) can do all of the above with no fixed
-          upload limit* PLUS make up to 100 of their own shakes, get a little plus sign next to
-          their name, and can have RSS feeds for their shakes. Even at just $2 per month, Double
-          Scoop members cover the primary expenses of running MLTSHP, and help make the Single
-          Scoop level possible.
+          The Double Scoop level ($24 per year) can do all of the above, plus:
+            <ul>
+                <li><strong>There are no fixed upload limits.</strong></li>
+                <li>Make up to 100 of their own group shakes.</li>
+                <li>Get a little plus sign next to their name.</li>
+                <li>Have RSS feeds for their shakes.</li>
+            </ul>
+          Even at just $2 per month, Double Scoop members cover the primary expenses of running 
+          MLTSHP and help make the Single Scoop level possible.
         </li>
       </ul>
       <p>

--- a/templates/misc/faq.html
+++ b/templates/misc/faq.html
@@ -31,7 +31,7 @@
             <ul>
                 <li>Post images and videos to their own shakes and to group shakes, up to a 
                     monthly upload limit of 300MB for images and animated GIFs.</li>
-                <li>Follow their friends' shakes and group shakes.</li>
+                <li>Follow their friends' shakes, and follow and join group shakes.</li>
                 <li>Save, like, and comment on any posts.</li>
             </ul>
         </li>

--- a/templates/misc/faq.html
+++ b/templates/misc/faq.html
@@ -14,9 +14,9 @@
         in April of 2017</a>. We are 100% community funded and member-run. The site is
         subscription-based and is a registered corporation. <a href="https://github.com/MLTSHP/mltshp">The
         code is on Github</a> along with <a href="https://github.com/MLTSHP/welcome">a welcome
-        module there</a> which talks about what is going on. There is also
-        <a href="https://mlkshk-v2.signup.team/">a Slack</a> and
-        <a href="https://www.facebook.com/groups/1833082553635028/?ref=bookmarks">a Facebook group</a>.
+        module there</a> which talks about what is going on. There is also a Slack (email <a 
+        href="mailto:hello@mltshp.com">hello@mltshp.com</a> for an invite!) and <a 
+        href="https://www.facebook.com/groups/1833082553635028/?ref=bookmarks">a Facebook group</a>.
       </p>
 
       <h2>What Do the Membership Levels Mean?</h2>


### PR DESCRIPTION
Clarified what the single and double scoop accounts can do, in list form for easier scannability.