### PR TITLE
Updating local dev docs to use 'mltshp.localhost'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ app itself using:
 
 This will do a lot of things. But ultimately, you should end up with a
 copy of MLTSHP running locally. It expects to be accessed via a hostname
-of `mltshp.local` and `s.mltshp.local`. Add these entries to your `/etc/hosts`
+of `mltshp.localhost` and `s.mltshp.localhost`. Add these entries to your `/etc/hosts`
 file:
 
-    127.0.0.1   mltshp.local s.mltshp.local
+    127.0.0.1   mltshp.localhost s.mltshp.localhost
 
 The web app itself runs on port 8000. You should be able to reach it via:
 
-[http://mltshp.local:8000/](http://mltshp.local:8000/)
+[http://mltshp.localhost:8000/](http://mltshp.localhost:8000/)
 
 Subsequent invocations of `make run` should be faster, once you have
 the dependency images downloaded.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     networks:
       app_net:
         aliases:
-          - mltshp.local
+          - mltshp.localhost
   fakes3:
     image: fingershock/fakes3
     volumes:

--- a/handlers/image.py
+++ b/handlers/image.py
@@ -556,7 +556,7 @@ class OEmbedHandler(BaseHandler):
             parsed_url = urlparse(self.get_argument('url', None))
         except:
             raise tornado.web.HTTPError(404)
-        if parsed_url.netloc not in [options.app_host, 'mltshp.local:8000', 'localhost:8000', 'localhost:81', 'www.' + options.app_host]:
+        if parsed_url.netloc not in [options.app_host, 'mltshp.localhost:8000', 'localhost:8000', 'localhost:81', 'www.' + options.app_host]:
             raise tornado.web.HTTPError(404)
         share_key = re.search("/p/([A-Za-z0-9]+)", parsed_url.path)
         if not share_key:

--- a/settings.example.py
+++ b/settings.example.py
@@ -1,8 +1,8 @@
 # Development settings; suitable for running against our Docker
 # image.
 settings = {
-    "app_host": "mltshp.local",
-    "cdn_host": "s.mltshp.local",
+    "app_host": "mltshp.localhost",
+    "cdn_host": "s.mltshp.localhost",
     "api_hits_per_hour" : 150,
     "auth_secret" : "dummy-secret",
     "aws_bucket": "mltshp-dev",


### PR DESCRIPTION
Chrome is having issues the a '.local' TLD, so I've changed our
documentation to recommend a '.localhost' TLD which should work for
all browsers.