### PR TITLE
Bugfix: Typo in ShakeHandler

### DIFF
--- a/handlers/api.py
+++ b/handlers/api.py
@@ -442,7 +442,7 @@ class ShakeHandler(BaseHandler):
     @oauth2authenticated
     def get(self, type, resource=''):
         shake = None
-        if type == 'shake_path':
+        if type == 'shake_name':
             shake = Shake.get('path=%s and deleted=0', resource)
         elif type == 'shake_id':
             shake = Shake.get('id=%s and deleted=0', resource)


### PR DESCRIPTION
This commit fixes a typo in ShakeHandler. It was looking for
`shake_path`, but the actual route is `shake_name`.