### PR TITLE
Faq page list styles

### DIFF
--- a/static/sass/areas/_faq.scss
+++ b/static/sass/areas/_faq.scss
@@ -8,7 +8,8 @@
     font-weight: bold;
 }
 
-.faq-page p {
+.faq-page p,
+.faq-page li {
     margin-top: 5px;
     font-size: 14px;
     line-height: 28px;

--- a/templates/misc/faq.html
+++ b/templates/misc/faq.html
@@ -14,8 +14,8 @@
         in April of 2017</a>. We are 100% community funded and member-run. The site is
         subscription-based and is a registered corporation. <a href="https://github.com/MLTSHP/mltshp">The
         code is on Github</a> along with <a href="https://github.com/MLTSHP/welcome">a welcome
-        module there</a> which talks about what is going on. There is also a Slack (email <a 
-        href="mailto:hello@mltshp.com">hello@mltshp.com</a> for an invite!) and <a 
+        module there</a> which talks about what is going on. There is also a Slack (email <a
+        href="mailto:hello@mltshp.com">hello@mltshp.com</a> for an invite!) and <a
         href="https://www.facebook.com/groups/1833082553635028/?ref=bookmarks">a Facebook group</a>.
       </p>
 
@@ -29,7 +29,7 @@
         <li>
           The Single Scoop level ($3 per year) is a great way to check out the site. Members can:
             <ul>
-                <li>Post images and videos to their own shakes and to group shakes, up to a 
+                <li>Post images and videos to their own shakes and to group shakes, up to a
                     monthly upload limit of 300MB for images and animated GIFs.</li>
                 <li>Follow their friends' shakes, and follow and join group shakes.</li>
                 <li>Save, like, and comment on any posts.</li>
@@ -43,7 +43,7 @@
                 <li>Get a little plus sign next to their name.</li>
                 <li>Have RSS feeds for their shakes.</li>
             </ul>
-          Even at just $2 per month, Double Scoop members cover the primary expenses of running 
+          Even at just $2 per month, Double Scoop members cover the primary expenses of running
           MLTSHP and help make the Single Scoop level possible.
         </li>
       </ul>
@@ -66,19 +66,19 @@
         You can upload JPG, GIF, or PNG files. You can post links to videos from YouTube, Vimeo, or Flickr.
       </p>
       <p>
-        Image files should be a reasonable size. Be nice to your 
+        Image files should be a reasonable size. Be nice to your
         friends on mobile phones or tablets. Be nice to our bandwidth quota. There's a hard limit of 20MB per image.
       </p>
-      
+
       <h2>Are There Other Rules Here?</h2>
       <p>
         There is a <a href="/terms-of-use">Terms of Use</a> and a <a href="/code-of-conduct">Code of Conduct</a>
         that cover most of them. We want this to be a positive place for people. If it's not, we want people to
         let us know before it becomes a larger problem.
       </p>
-        
+
       <h2>How Do I Contact Someone?</h2>
-      <p>You can contact us directly by email 
+      <p>You can contact us directly by email
         at <a href="mailto:hello@mltshp.com">hello@mltshp.com</a>. We'll try to respond as quickly as possible.
       </p>
 
@@ -91,10 +91,10 @@
         our Slack</a>. Check our <a href="https://github.com/MLTSHP/mltshp/wiki/Browser-Support-Matrix">Browser
         Support Matrix</a> to make sure you are using a supported browser. Thanks for helping!
       </p>
-      
+
       <h2>How Can I use RSS to Follow the Best of MLTSHP Account?</h2>
       <p>
-        Using some magic, the <a href="/user/mltshp">MLTSHP</a> user saves some of the best 
+        Using some magic, the <a href="/user/mltshp">MLTSHP</a> user saves some of the best
         images from the site. You can access that RSS feed with <a href="/user/mltshp/rss">this link</a>
         or follow <a href="https://twitter.com/best_of_mltshp">@Best_of_MLTSHP</a> on Twitter.
       </p>
@@ -111,30 +111,30 @@
         Plugins <a href="/tools/plugins">can be found here</a>. If you'd like to make one, please
         email us and we can walk you through what we'd need.
       </p>
-        
+
       <h2>How Do I Change My Password?</h2>
       <p>
         To reset your password, go to the <a href="/account/forgot-password">Lost Password page</a>
         linked from the sign in page. You will be emailed instructions on how to reset your password.
       </p>
-        
+
       <h2>Why Are You Giving Me Grief About My Password?</h2>
       <a name="bad_password"></a>
       <p>
-        Given the recent news of password hijacking and fears about security, we took 
-        <a href="http://www.whatsmypass.com/the-top-500-worst-passwords-of-all-time">a popular list of bad passwords</a> 
+        Given the recent news of password hijacking and fears about security, we took
+        <a href="http://www.whatsmypass.com/the-top-500-worst-passwords-of-all-time">a popular list of bad passwords</a>
         and match them against passwords being used to create accounts on MLTSHP. Try again?
       </p>
-        
+
       <h2>Can I Use Keyboard Commands for Navigation?</h2>
       <p>
         Yes! Here is what we support:
       </p>
       <ul>
-        <li>h - page down, h again navigates to "older"</li>
-        <li>j - next post, j at the end of the page navigates to "older"</li>
-        <li>k - previous post, k at the top of the page navigates to "newer"</li>
-        <li>l - page up, l again navigates to "newer"</li>
+        <li><kbd>h</kbd> - page down, <kbd>h</kbd> again navigates to "older"</li>
+        <li><kbd>j</kbd> - next post, <kbd>j</kbd> at the end of the page navigates to "older"</li>
+        <li><kbd>k</kbd> - previous post, <kbd>k</kbd> at the top of the page navigates to "newer"</li>
+        <li><kbd>l</kbd> - page up, <kbd>l</kbd> again navigates to "newer"</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
This PR applies the existing styles for paragraphs on the FAQ page to list items as well, which were previously unstyled.

It also adds `<kbd>` elements for the keyboard commands listed on the FAQ page.

Fixes #574 