### PR TITLE
Fix font size in new post panel on small screens

### DIFF
--- a/static/sass/components/_new-post-panel.scss
+++ b/static/sass/components/_new-post-panel.scss
@@ -195,9 +195,15 @@
 }
 
 .new-post-panel h2 {
-    font-size: 60px;
+    font-size: 30px;
     font-weight: bold;
     margin: 0 0 20px 0;
+}
+
+@media screen and (min-width: 768px) {
+    .new-post-panel h2 {
+        font-size: 60px;
+    }
 }
 
 .new-post-panel p {


### PR DESCRIPTION
This commit fixes a bug where enormous font size for the title of the new post panel made it impossible to submit on very small screens like the iPhone 5.

Fixes #465 

## Screenshot

![Screen Shot 2020-02-17 at 5 08 02 PM](https://user-images.githubusercontent.com/257309/74695346-87a03300-51a8-11ea-8cc7-e760a4cac184.png)
