### PR TITLE
Bugfix: `shake_name` should look up by name

### DIFF
--- a/handlers/api.py
+++ b/handlers/api.py
@@ -443,7 +443,7 @@ class ShakeHandler(BaseHandler):
     def get(self, type, resource=''):
         shake = None
         if type == 'shake_name':
-            shake = Shake.get('path=%s and deleted=0', resource)
+            shake = Shake.get('name=%s and deleted=0', resource)
         elif type == 'shake_id':
             shake = Shake.get('id=%s and deleted=0', resource)
 


### PR DESCRIPTION
This commit fixes a bug where the `shake_name` api route was trying to
look up the shake by `path` rather than `name`.