### PR TITLE
Bugfix: Typo in Shake Name RegEx

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -20,7 +20,7 @@ routes = [
     (r"/api/shakes", handlers.api.UserShakesHandler),
     (r"/api/(shake_id)/([0-9]+)",
         handlers.api.ShakeHandler),
-    (r"/api/(shake_name)/([^a-zA-Z0-9\-]+)",
+    (r"/api/(shake_name)/([a-zA-Z0-9\-]+)",
         handlers.api.ShakeHandler),
     (r"/api/shakes/([0-9]+)", handlers.api.ShakeStreamHandler),
     (r"/api/shakes/([0-9]+)/(before|after)/([\a-zA-Z0-9]+)",


### PR DESCRIPTION
This regex was copied from the Shake's "is this a valid name" method,
which was searching for NOT allowed characters. For the route, we want
to search for allowed characters.