### PR TITLE
Add Endpoint to Retreive a User's Shake

### DIFF
--- a/developerdocs/reference.rst
+++ b/developerdocs/reference.rst
@@ -186,6 +186,15 @@ The resources (URL endpoints) in the MLTSHP API are:
    :status 404: no such shake with that pathname
 
 
+.. http:get:: /api/shake_user/(username)
+
+   Returns information for the shake belonging to the specified user.
+
+   :param username: the user's username
+   :status 200: the response is the requested :entity:`shake`
+   :status 404: no such user with that name
+
+
 .. http:get:: /api/shakes
 
    Returns the authorized user's shakes.
@@ -296,4 +305,4 @@ The resources (URL endpoints) in the MLTSHP API are:
 
    :param username: the user's username
    :status 200: the response is the requested :entity:`user`
-   :status 404: no such user with that ID
+   :status 404: no such user with that name

--- a/handlers/api.py
+++ b/handlers/api.py
@@ -447,7 +447,7 @@ class ShakeHandler(BaseHandler):
         elif type == 'shake_id':
             shake = Shake.get('id=%s and deleted=0', resource)
         elif type == 'shake_user':
-            shake = User.get('name=%s', resource).shake()
+            shake = User.get('name=%s and deleted=0', resource).shake()
 
         if not shake:
             self.set_status(404)

--- a/handlers/api.py
+++ b/handlers/api.py
@@ -447,7 +447,9 @@ class ShakeHandler(BaseHandler):
         elif type == 'shake_id':
             shake = Shake.get('id=%s and deleted=0', resource)
         elif type == 'shake_user':
-            shake = User.get('name=%s and deleted=0', resource).shake()
+            user = User.get('name=%s and deleted=0', resource)
+            if user is not None:
+                shake = user.shake()
 
         if not shake:
             self.set_status(404)

--- a/handlers/api.py
+++ b/handlers/api.py
@@ -446,6 +446,8 @@ class ShakeHandler(BaseHandler):
             shake = Shake.get('name=%s and deleted=0', resource)
         elif type == 'shake_id':
             shake = Shake.get('id=%s and deleted=0', resource)
+        elif type == 'shake_user':
+            shake = User.get('name=%s', resource).shake()
 
         if not shake:
             self.set_status(404)

--- a/routes.py
+++ b/routes.py
@@ -22,6 +22,8 @@ routes = [
         handlers.api.ShakeHandler),
     (r"/api/(shake_name)/([a-zA-Z0-9\-]+)",
         handlers.api.ShakeHandler),
+    (r"/api/(shake_user)/([a-zA-Z0-9\-]+)",
+        handlers.api.ShakeHandler),
     (r"/api/shakes/([0-9]+)", handlers.api.ShakeStreamHandler),
     (r"/api/shakes/([0-9]+)/(before|after)/([\a-zA-Z0-9]+)",
         handlers.api.ShakeStreamHandler),

--- a/routes.py
+++ b/routes.py
@@ -22,7 +22,7 @@ routes = [
         handlers.api.ShakeHandler),
     (r"/api/(shake_name)/([a-zA-Z0-9\-]+)",
         handlers.api.ShakeHandler),
-    (r"/api/(shake_user)/([a-zA-Z0-9\-]+)",
+    (r"/api/(shake_user)/([a-zA-Z0-9_\-]+)",
         handlers.api.ShakeHandler),
     (r"/api/shakes/([0-9]+)", handlers.api.ShakeStreamHandler),
     (r"/api/shakes/([0-9]+)/(before|after)/([\a-zA-Z0-9]+)",

--- a/templates/developers/reference.html
+++ b/templates/developers/reference.html
@@ -391,6 +391,29 @@
 </dd></dl>
 
 <dl class="get">
+<dt id="get--api-shake_user-(username)">
+<code class="descname">GET </code><code class="descname">/api/shake_user/</code><span class="sig-paren">(</span><em>username</em><span class="sig-paren">)</span><a class="headerlink" href="#get--api-shake_user-(username)" title="Permalink to this definition">¶</a></dt>
+<dd><p>Returns information for the shake belonging to the specified user.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>username</strong> – the user’s username</li>
+</ul>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Status Codes:</th><td class="field-body"><ul class="first last simple">
+<li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1">200 OK</a> – the response is the requested <a class="reference internal" href="#entity-shake"><em class="xref std std-entity">shake</em></a></li>
+<li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">404 Not Found</a> – no such user with that name</li>
+</ul>
+</td>
+</tr>
+</tbody>
+</table>
+</dd></dl>
+
+<dl class="get">
 <dt id="get--api-shakes">
 <code class="descname">GET </code><code class="descname">/api/shakes</code><a class="headerlink" href="#get--api-shakes" title="Permalink to this definition">¶</a></dt>
 <dd><p>Returns the authorized user’s shakes.</p>
@@ -656,7 +679,7 @@ unless the shake_id parameter is provided.</p>
 </tr>
 <tr class="field-even field"><th class="field-name">Status Codes:</th><td class="field-body"><ul class="first last simple">
 <li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1">200 OK</a> – the response is the requested <a class="reference internal" href="#entity-user"><em class="xref std std-entity">user</em></a></li>
-<li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">404 Not Found</a> – no such user with that ID</li>
+<li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.5">404 Not Found</a> – no such user with that name</li>
 </ul>
 </td>
 </tr>


### PR DESCRIPTION
This commit adds a new `shake_user` endpoint to which you can pass a username to retrieve the details for that user's personal shake.

Note, I'm just stubbing this out. If `shake_user` isn't the right name, or if the logic is wrong, let me know.