### PR TITLE
Chore/text changes

### DIFF
--- a/developerdocs/README.md
+++ b/developerdocs/README.md
@@ -1,0 +1,34 @@
+# Developer Documentation
+
+## About
+
+This directory contains some documentation regarding the MLTSHP API. The documentation
+is in REST format and is built using Sphinx. If any updates are made to the API,
+corresponding updates should be made to this documentation to keep things in sync.
+The documentation is readable through the site, but as static HTML, which has to be
+built from this directory. The resulting HTML files need to be checked in along with
+the API code changes.
+
+## Setting Up
+
+To build the documentation HTML files, you'll need to do the usual Python virtualenv
+steps if you haven't already. Then, with the virtualenv active, install the special
+requirements like this:
+
+    $ pip install -r developerdocs/requirements.txt
+
+(You'd issue this from the top of the MLTSHP repository, with the virtualenv for it
+already active.)
+
+## Building
+
+With the setup steps done, building the documentation is just a matter of executing
+the `make` command from the directory.
+
+    $ cd developerdocs
+    $ make
+
+That should produce the updates to the HTML files (in templates/developers). You
+will need to add any updates to those files to your git branch and commit them
+along with your API changes.
+

--- a/developerdocs/reference.rst
+++ b/developerdocs/reference.rst
@@ -42,7 +42,7 @@ Responses from the MLTSHP API are :mimetype:`application/json` responses that re
    :key comments: the number of :entity:`comments <comment>` on the file
    :key nsfw: whether the file has been marked NSFW, and so is hidden by default when displayed on MLTSHP (`true` for NSFW/hidden, `false` for SFW/visible)
    :key original_image_url: if the file is an image, the URL of the image on MLTSHP
-   :key source_url: if the file is *not* an image, the original URL of the shared item
+   :key url: if the file is *not* an image, the original URL of the shared item
    :key pivot_id: a key that is used for pagination. It varies based on the API method.
    :key saved: flag indicating whether authenticated user has already saved the sharedfile
    :key liked: flag indicating whether authenticated user has already liked the sharedfile
@@ -115,8 +115,8 @@ The resources (URL endpoints) in the MLTSHP API are:
 
 
 .. http:get:: /api/magicfiles
-.. http:get:: /api/magicfiles/(id)/before/(beforekey)
-.. http:get:: /api/magicfiles/(id)/after/(afterkey)
+.. http:get:: /api/magicfiles/before/(beforekey)
+.. http:get:: /api/magicfiles/after/(afterkey)
 
    Returns the 10 most recent files accepted by the "magic" file selection algorithm. Currently any files with 10 or more likes are magic.
 
@@ -131,8 +131,8 @@ The resources (URL endpoints) in the MLTSHP API are:
 
 
 .. http:get:: /api/incoming
-.. http:get:: /api/incoming/(id)/before/(beforekey)
-.. http:get:: /api/incoming/(id)/after/(afterkey)
+.. http:get:: /api/incoming/before/(beforekey)
+.. http:get:: /api/incoming/after/(afterkey)
 
    Returns the 10 most recently posted sharedfiles.
 
@@ -140,7 +140,6 @@ The resources (URL endpoints) in the MLTSHP API are:
 
    :param beforekey: the :entity:`pivot_id` of the file to show posts before
    :param afterkey: the :entity:`pivot_id` of the file to show posts after
-   :param filter_nsfw: determines whether NSFW users get filtered from result. Set to True by default.
 
    :status 200: the response is the latest files as an object containing:
 
@@ -243,7 +242,7 @@ The resources (URL endpoints) in the MLTSHP API are:
    unless the shake_id parameter is provided.
 
    :param sharekey: the :entity:`sharekey` of the file to save
-   :param shake_id: the id of the destination :entity:`shake` the file should be saved to (optional)
+   :form shake_id: the id of the destination :entity:`shake` the file should be saved to (optional)
    :status 200: the file was saved, and the response is the saved :entity:`sharedfile`
    :status 400: the file could not be saved, probably because the file belongs to the authenticated user
    :status 403: the file could not be saved due to permission issues
@@ -278,7 +277,7 @@ The resources (URL endpoints) in the MLTSHP API are:
    :form shake_id: numeric ID of the shake to post to (optional)
    :form title: text for the image title (optional)
    :form description: text for the image description (optional)
-   :status 201: the image was posted to the shake, and the response body is a :entity:`sharedfile` representing it
+   :status 201: the image was posted to the shake, and the response body is an abbreviated :entity:`sharedfile` representing it, containing only :entity:`sharekey` and name
    :status 400: the file could not be identified as an image
 
 

--- a/static/50x.html
+++ b/static/50x.html
@@ -40,7 +40,6 @@
                 &nbsp; <a href="/terms-of-use">Terms of Use</a>
                 &nbsp; <a href="/code-of-conduct">Code of Conduct</a>
                 &nbsp; <a href="mailto:hello@mltshp.com">Contact Us</a>
-                &nbsp; <a href="https://mlkshk-v2.signup.team/">Join us on Slack</a>
                 &nbsp; <a href="https://twitter.com/best_of_mltshp">@best_of_mltshp</a>
             </p>
             <p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -158,7 +158,6 @@
                     &nbsp; <a href="/terms-of-use">Terms of Use</a>
                     &nbsp; <a href="/code-of-conduct">Code of Conduct</a>
                     &nbsp; <a href="mailto:hello@mltshp.com">Contact Us</a>
-                    &nbsp; <a href="https://mlkshk-v2.signup.team/">Join us on Slack</a>
                     &nbsp; <a href="https://twitter.com/best_of_mltshp">@best_of_mltshp</a>
                 </p>
                 <p>

--- a/templates/developers/reference.html
+++ b/templates/developers/reference.html
@@ -83,7 +83,7 @@
 <li><strong>comments</strong> – the number of <a class="reference internal" href="#entity-comment"><em class="xref std std-entity">comments</em></a> on the file</li>
 <li><strong>nsfw</strong> – whether the file has been marked NSFW, and so is hidden by default when displayed on MLTSHP (<cite>true</cite> for NSFW/hidden, <cite>false</cite> for SFW/visible)</li>
 <li><strong>original_image_url</strong> – if the file is an image, the URL of the image on MLTSHP</li>
-<li><strong>source_url</strong> – if the file is <em>not</em> an image, the original URL of the shared item</li>
+<li><strong>url</strong> – if the file is <em>not</em> an image, the original URL of the shared item</li>
 <li><strong>pivot_id</strong> – a key that is used for pagination. It varies based on the API method.</li>
 <li><strong>saved</strong> – flag indicating whether authenticated user has already saved the sharedfile</li>
 <li><strong>liked</strong> – flag indicating whether authenticated user has already liked the sharedfile</li>
@@ -233,13 +233,13 @@
 <dd></dd></dl>
 
 <dl class="get">
-<dt id="get--api-magicfiles-(id)-before-(beforekey)">
-<code class="descname">GET </code><code class="descname">/api/magicfiles/</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><code class="descname">/before/</code><span class="sig-paren">(</span><em>beforekey</em><span class="sig-paren">)</span><a class="headerlink" href="#get--api-magicfiles-(id)-before-(beforekey)" title="Permalink to this definition">¶</a></dt>
+<dt id="get--api-magicfiles-before-(beforekey)">
+<code class="descname">GET </code><code class="descname">/api/magicfiles/before/</code><span class="sig-paren">(</span><em>beforekey</em><span class="sig-paren">)</span><a class="headerlink" href="#get--api-magicfiles-before-(beforekey)" title="Permalink to this definition">¶</a></dt>
 <dd></dd></dl>
 
 <dl class="get">
-<dt id="get--api-magicfiles-(id)-after-(afterkey)">
-<code class="descname">GET </code><code class="descname">/api/magicfiles/</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><code class="descname">/after/</code><span class="sig-paren">(</span><em>afterkey</em><span class="sig-paren">)</span><a class="headerlink" href="#get--api-magicfiles-(id)-after-(afterkey)" title="Permalink to this definition">¶</a></dt>
+<dt id="get--api-magicfiles-after-(afterkey)">
+<code class="descname">GET </code><code class="descname">/api/magicfiles/after/</code><span class="sig-paren">(</span><em>afterkey</em><span class="sig-paren">)</span><a class="headerlink" href="#get--api-magicfiles-after-(afterkey)" title="Permalink to this definition">¶</a></dt>
 <dd><p>Returns the 10 most recent files accepted by the “magic” file selection algorithm. Currently any files with 10 or more likes are magic.</p>
 <p>Use the <code class="samp docutils literal notranslate"><span class="pre">before/</span><em><span class="pre">beforekey</span></em></code> and <code class="samp docutils literal notranslate"><span class="pre">after/</span><em><span class="pre">afterkey</span></em></code> variations to page through the sharedfiles. That is, specify the last <em class="xref std std-entity">pivot_id</em> as the key to the <code class="samp docutils literal notranslate"><span class="pre">before/</span><em><span class="pre">beforekey</span></em></code> resource to get the page of files saved before the current page.</p>
 <table class="docutils field-list" frame="void" rules="none">
@@ -271,13 +271,13 @@
 <dd></dd></dl>
 
 <dl class="get">
-<dt id="get--api-incoming-(id)-before-(beforekey)">
-<code class="descname">GET </code><code class="descname">/api/incoming/</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><code class="descname">/before/</code><span class="sig-paren">(</span><em>beforekey</em><span class="sig-paren">)</span><a class="headerlink" href="#get--api-incoming-(id)-before-(beforekey)" title="Permalink to this definition">¶</a></dt>
+<dt id="get--api-incoming-before-(beforekey)">
+<code class="descname">GET </code><code class="descname">/api/incoming/before/</code><span class="sig-paren">(</span><em>beforekey</em><span class="sig-paren">)</span><a class="headerlink" href="#get--api-incoming-before-(beforekey)" title="Permalink to this definition">¶</a></dt>
 <dd></dd></dl>
 
 <dl class="get">
-<dt id="get--api-incoming-(id)-after-(afterkey)">
-<code class="descname">GET </code><code class="descname">/api/incoming/</code><span class="sig-paren">(</span><em>id</em><span class="sig-paren">)</span><code class="descname">/after/</code><span class="sig-paren">(</span><em>afterkey</em><span class="sig-paren">)</span><a class="headerlink" href="#get--api-incoming-(id)-after-(afterkey)" title="Permalink to this definition">¶</a></dt>
+<dt id="get--api-incoming-after-(afterkey)">
+<code class="descname">GET </code><code class="descname">/api/incoming/after/</code><span class="sig-paren">(</span><em>afterkey</em><span class="sig-paren">)</span><a class="headerlink" href="#get--api-incoming-after-(afterkey)" title="Permalink to this definition">¶</a></dt>
 <dd><p>Returns the 10 most recently posted sharedfiles.</p>
 <p>Use the <code class="samp docutils literal notranslate"><span class="pre">before/</span><em><span class="pre">beforekey</span></em></code> and <code class="samp docutils literal notranslate"><span class="pre">after/</span><em><span class="pre">afterkey</span></em></code> variations to page through the sharedfiles. That is, specify the last <em class="xref std std-entity">pivot_id</em> as the key to the <code class="samp docutils literal notranslate"><span class="pre">before/</span><em><span class="pre">beforekey</span></em></code> resource to get the page of files saved before the current page.</p>
 <table class="docutils field-list" frame="void" rules="none">
@@ -287,7 +287,6 @@
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
 <li><strong>beforekey</strong> – the <em class="xref std std-entity">pivot_id</em> of the file to show posts before</li>
 <li><strong>afterkey</strong> – the <em class="xref std std-entity">pivot_id</em> of the file to show posts after</li>
-<li><strong>filter_nsfw</strong> – determines whether NSFW users get filtered from result. Set to True by default.</li>
 </ul>
 </td>
 </tr>
@@ -524,11 +523,16 @@ unless the shake_id parameter is provided.</p>
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
 <li><strong>sharekey</strong> – the <a class="reference internal" href="#entity-sharekey"><em class="xref std std-entity">sharekey</em></a> of the file to save</li>
+</ul>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name" colspan="2">Form Parameters:</th></tr>
+<tr class="field-even field"><td>&#160;</td><td class="field-body"><ul class="first simple">
 <li><strong>shake_id</strong> – the id of the destination <a class="reference internal" href="#entity-shake"><em class="xref std std-entity">shake</em></a> the file should be saved to (optional)</li>
 </ul>
 </td>
 </tr>
-<tr class="field-even field"><th class="field-name">Status Codes:</th><td class="field-body"><ul class="first last simple">
+<tr class="field-odd field"><th class="field-name">Status Codes:</th><td class="field-body"><ul class="first last simple">
 <li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1">200 OK</a> – the file was saved, and the response is the saved <a class="reference internal" href="#entity-sharedfile"><em class="xref std std-entity">sharedfile</em></a></li>
 <li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1">400 Bad Request</a> – the file could not be saved, probably because the file belongs to the authenticated user</li>
 <li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.4">403 Forbidden</a> – the file could not be saved due to permission issues</li>
@@ -615,7 +619,7 @@ unless the shake_id parameter is provided.</p>
 </td>
 </tr>
 <tr class="field-even field"><th class="field-name">Status Codes:</th><td class="field-body"><ul class="first last simple">
-<li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.2">201 Created</a> – the image was posted to the shake, and the response body is a <a class="reference internal" href="#entity-sharedfile"><em class="xref std std-entity">sharedfile</em></a> representing it</li>
+<li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.2">201 Created</a> – the image was posted to the shake, and the response body is an abbreviated <a class="reference internal" href="#entity-sharedfile"><em class="xref std std-entity">sharedfile</em></a> representing it, containing only <a class="reference internal" href="#entity-sharekey"><em class="xref std std-entity">sharekey</em></a> and name</li>
 <li><a class="reference external" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1">400 Bad Request</a> – the file could not be identified as an image</li>
 </ul>
 </td>

--- a/templates/misc/faq.html
+++ b/templates/misc/faq.html
@@ -87,8 +87,9 @@
         You can <a href="https://github.com/MLTSHP/mltshp/issues">file a ticket on Github</a> (preferred,
         if you have a Github account), or use this
         <a href="https://docs.google.com/forms/d/e/1FAIpQLSfK02m7I_lLPSBJ88pq8z1sQXF-WwKy0Cp_GnsI9zfeAtBaHA/viewform?c=0&amp;w=1">Issue
-        Report Form</a>, or talk to people in realtime <a href="https://mlkshk-v2.signup.team/">on
-        our Slack</a>. Check our <a href="https://github.com/MLTSHP/mltshp/wiki/Browser-Support-Matrix">Browser
+        Report Form</a>, or talk to people in realtime on
+        our Slack (email <a href="mailto:hello@mltshp.com">hello@mltshp.com</a> for an invite!).
+        Check our <a href="https://github.com/MLTSHP/mltshp/wiki/Browser-Support-Matrix">Browser
         Support Matrix</a> to make sure you are using a supported browser. Thanks for helping!
       </p>
 

--- a/templates/upload/error.html
+++ b/templates/upload/error.html
@@ -5,7 +5,7 @@
     {% if error_type == 'content_type' %}
     <h1 class="error-uh-oh">We don't support that file type.</h1>
     <p class="error-p">
-      Right now we only support uploading gif's, jpeg's &amp; png's.
+      Right now we only support uploading GIF, JPEG &amp; PNG images.
     </p>
     {% elif error_type == 'upload_limit' %}
     <h1 class="error-uh-oh">Single Scoop Account Limit.</h1>


### PR DESCRIPTION
## Remove Slack link from footer

This commit removes the Slack link from the footer, and updates the remaining reference to it in the FAQ with an "email for access" link. We're removing these links because you can't actually sign up for the Slack, you have to be invited.

Fixes #591

## Remove Unneeded Apostrophes

This commit fixes a grammar bug on the Error page that used apostrophes for the phrase "gif's, jpeg's & png's". It's been replaced with "GIF, JPEG & PNG images".

Fixes #595

## API Documentation Corrections

This commit fixes a few mistakes in the API documentation:

- sharedfile: replace source_url with actual value, url
- magicfiles: remove (id) from pagination endpoints.
- incoming: remove (id) from pagination endpoints.
- incoming: filter_nsfw parameter does not actually exist
- save: the shake_id parameter should be a form parameter
- upload: the response body actually only contains share_key and name

Fixes #590