### PR TITLE
Remove `- mltshp` from image detail titles

### DIFF
--- a/templates/image/show.html
+++ b/templates/image/show.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{escape(sharedfile.get_title())}} - mltshp{% end %}
+{% block title %}{{escape(sharedfile.get_title())}}{% end %}
 {% block included_headers %}
 <link rel="alternate"
       type="application/json+oembed"


### PR DESCRIPTION
It’s redundant since all pages already end in `| MLTSHP`.

Example for this page: https://mltshp.com/p/1HUL2

Before:
`Landscape / Riancho y Gómez de Porras, Agustín - mltshp | MLTSHP`

After:
`Landscape / Riancho y Gómez de Porras, Agustín | MLTSHP`