### PR TITLE
Image optimizations

### DIFF
--- a/handlers/image.py
+++ b/handlers/image.py
@@ -123,6 +123,12 @@ class ShowHandler(BaseHandler):
         thumb_url = s3_authenticated_url(options.aws_key, options.aws_secret, options.aws_bucket, file_path="thumbnails/%s" % (sourcefile.thumb_key), seconds=3600)
         jsonp = 'jsonp%s' % int(time.mktime(sharedfile.created_at.timetuple()))
 
+        # OpenGraph recommendation for image size is 1200x630
+        og_width = None
+        og_height = None
+        if sourcefile.type == 'image':
+            og_width, og_height = sourcefile.width_constrained_dimensions(1200)
+
         return self.render("image/show.html", sharedfile=sharedfile, thumb_url=thumb_url,
             sharedfile_owner=sharedfile_owner, image_url=image_url, jsonp=jsonp,
             view_count=view_count, can_delete=can_delete, save_count=save_count,
@@ -131,7 +137,8 @@ class ShowHandler(BaseHandler):
             add_to_shakes=add_to_shakes, can_add_to_shakes=can_add_to_shakes,
             can_comment=can_comment,
             owner_twitter_account=owner_twitter_account,
-            user_is_owner=user_is_owner)
+            user_is_owner=user_is_owner,
+            og_width=og_width, og_height=og_height)
 
 
 class ShowLikesHandler(BaseHandler):

--- a/setup/db-install.sql
+++ b/setup/db-install.sql
@@ -291,7 +291,7 @@ CREATE TABLE `shake_manager` (
   `created_at` datetime DEFAULT NULL,
   `updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `payment_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,

--- a/templates/image/show.html
+++ b/templates/image/show.html
@@ -21,7 +21,7 @@
 {% end %}
 {% if sourcefile.type == 'image' %}
 <meta property="twitter:card" content="photo">
-<meta property="og:image" content="https://mltshp-cdn.com/r/{{sharedfile.share_key}}">
+<meta property="og:image" content="https://mltshp-cdn.com/r/{{sharedfile.share_key}}?width=800">
 <meta property="og:image:type" content="image/{{sharedfile.content_type}}">
 <meta property="og:image:width" content="{{sourcefile.width}}">
 <meta property="og:image:height" content="{{sourcefile.height}}">

--- a/templates/uimodules/image.html
+++ b/templates/uimodules/image.html
@@ -61,7 +61,7 @@
                     {% if list_view %}
                         <a href="/p/{{sharedfile.share_key}}"><img src="//s.{{host}}/r/{{sharedfile.share_key}}" alt="{{escape(sharedfile.get_title())}}"></a>
                     {% else %}
-                        <a href="//{{cdn_host}}/r/{{sharedfile.share_key}}"><img src="//s.{{host}}/r/{{sharedfile.share_key}}" alt="{{escape(sharedfile.get_title())}}"></a>
+                        <a href="//{{cdn_host}}/r/{{sharedfile.share_key}}"><img src="//s.{{host}}/r/{{sharedfile.share_key}}?width={{sized_width}}" height="{{sized_height}}" width="{{sized_width}}" alt="{{escape(sharedfile.get_title())}}"></a>
                     {% end %}
                 {% end %}
             {% end %}

--- a/test.py
+++ b/test.py
@@ -82,5 +82,8 @@ if __name__ == '__main__':
         with open("setup/db-install.sql") as f:
             load_query = f.read()
         db.execute("USE %s" % options.database_name)
-        db.execute(load_query)
+        statements = load_query.split(";")
+        for statement in statements:
+            if statement.strip() != "":
+                db.execute(statement.strip())
     tornado.testing.main()

--- a/test/base.py
+++ b/test/base.py
@@ -76,7 +76,10 @@ class BaseAsyncTestCase(AsyncHTTPTestCase, LogTrapTestCase):
         load_query = f.read()
         f.close()
         f = None
-        db.execute(load_query)
+        statements = load_query.split(";")
+        for statement in statements:
+            if statement.strip() != "":
+                db.execute(statement.strip())
         end_time = int(time.time())
         #print "Database reset took: %s" % (end_time - start_time)
         return db

--- a/test/unit/base.py
+++ b/test/unit/base.py
@@ -20,7 +20,10 @@ class BaseTestCase(unittest.TestCase):
         f = open("setup/db-install.sql")
         load_query = f.read()
         f.close()
-        db.execute(load_query)
+        statements = load_query.split(";")
+        for statement in statements:
+            if statement.strip() != "":
+                db.execute(statement.strip())
         return db
         
     def generate_string_of_len(self, length):


### PR DESCRIPTION
Use width query parameter for Fastly image optimization

Constraining width to 550px for shake views. Links to full
resolution image are still going to display the full image.

Assigning height/width values for img tags for shake views which
should reduce content layout shift.

Constraining width to 1200px for opengraph meta image links.