### PR TITLE
Update to commands to execute within docker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,17 @@ build:
 	docker build -t mltshp/mltshp-web:latest .
 
 shell:
-	docker exec -it mltshp_mltshp_1 bash
+	docker-compose exec mltshp bash
 
 test:
-	docker exec -it mltshp_mltshp_1 su ubuntu -c "cd /srv/mltshp.com/mltshp; python test.py $(TEST)"
+	docker-compose exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; python test.py $(TEST)"
 
 destroy:
 	docker-compose down
 	rm -rf mounts
 
 migrate:
-	docker exec -it mltshp_mltshp_1 su ubuntu -c "cd /srv/mltshp.com/mltshp; python migrate.py"
+	docker-compose exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; python migrate.py"
 
 mysql:
-	docker exec -it mltshp_mltshp_1 su ubuntu -c "cd /srv/mltshp.com/mltshp; mysql -u root --host mysql mltshp"
+	docker-compose exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; mysql -u root --host mysql mltshp"


### PR DESCRIPTION
Updating exec commands to use docker-compose instead of docker, since we cannot assume the name of the container anymore (docker-compose v2 changed from using '_' to '-' for composing the container names).