### PR TITLE
Pass through dpr query parameter

### DIFF
--- a/handlers/image.py
+++ b/handlers/image.py
@@ -252,10 +252,12 @@ class ShowRawHandler(BaseHandler):
             if format != "":
                 cdn_url += ".%s" % format
 
-            # Pass through width query parameter if present
+            # Pass through width and dpr query parameter if present.
+            # These are supported by Fastly for rendering variant images.
             if self.get_argument("width", None) is not None:
                 try:
                     cdn_url += "?width=%d" % int(self.get_argument("width"))
+                    cdn_url += ("&dpr=%.1f" % float(self.get_argument("dpr", "1"))).replace(".0", "")
                 except ValueError:
                     pass
 

--- a/test/SiteFunctionTests.py
+++ b/test/SiteFunctionTests.py
@@ -88,7 +88,21 @@ class FileViewTests(BaseAsyncTestCase):
 
         response = self.wait()
         options.use_cdn = False
-        self.assertEquals(response.headers['location'], 'https://mltshp-cdn.com/r/1?width=550')
+        self.assertEquals(response.headers['location'], 'https://mltshp-cdn.com/r/1?width=550&dpr=1')
+
+    def test_cdn_image_view_with_width_and_dpr(self):
+        response = self.upload_file(self.test_file1_path, self.test_file1_sha1,
+            self.test_file1_content_type, 1, self.sid, self.xsrf)
+
+        options.use_cdn = True
+        request = HTTPRequest(self.get_url('/r/1?width=550&dpr=2'), 'GET',
+            {"Cookie": "sid=%s" % (self.sid), "Host": "s.mltshp.com"},
+            follow_redirects=False)
+        self.http_client.fetch(request, self.stop)
+
+        response = self.wait()
+        options.use_cdn = False
+        self.assertEquals(response.headers['location'], 'https://mltshp-cdn.com/r/1?width=550&dpr=2')
 
     def test_raw_image_view_counts(self):
         response = self.upload_file(self.test_file1_path, self.test_file1_sha1,


### PR DESCRIPTION
When present, pass through the `dpr` query parameter, or a default value of `1`.