### PR TITLE
Changing fakes3 docker image

### DIFF
--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -29,7 +29,8 @@ services:
     networks:
       - app_net
   fakes3:
-    image: fingershock/fakes3
+    image: ourtownrentals/fake-s3
+    entrypoint: fakes3 -r /srv --license ${FAKES3_LICENSE_KEY} -p 8000
     ports:
       - "8000:8000"
     networks:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pip-log.txt
 *.swp
 env
 mounts
+.env
 .deploy.env
 .coverage
 coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -6,26 +6,26 @@ init-dev:
 	mkdir -p mounts/mysql mounts/logs mounts/fakes3 mounts/uploaded
 
 run:
-	docker-compose up -d
+	docker-compose --env-file .env up -d
 
 stop:
-	docker-compose down
+	docker-compose --env-file .env down
 
 build:
 	docker build -t mltshp/mltshp-web:latest .
 
 shell:
-	docker-compose exec mltshp bash
+	docker-compose --env-file .env exec mltshp bash
 
 test:
-	docker-compose exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; python test.py $(TEST)"
+	docker-compose --env-file .env exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; python test.py $(TEST)"
 
 destroy:
 	docker-compose down
 	rm -rf mounts
 
 migrate:
-	docker-compose exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; python migrate.py"
+	docker-compose --env-file .env exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; python migrate.py"
 
 mysql:
-	docker-compose exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; mysql -u root --host mysql mltshp"
+	docker-compose --env-file .env exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; mysql -u root --host mysql mltshp"

--- a/README.md
+++ b/README.md
@@ -93,10 +93,20 @@ That should do it.
 
 ## Tests
 
-With your copy of MLTSHP running, you may want to run unit tests. Some
-of the unit tests actually test against Twitter itself, so you'll want
-to generate a custom Twitter app with your own set of keys. Configure
-the `test_settings` in your `settings.py` file appropriately:
+With your copy of MLTSHP running, you may want to run unit tests.
+
+Some tests rely on accessing AWS S3. We have a dummy S3 server in
+place to mock those API requests. But it requires a license key
+in order to use it. Visit [this page](https://supso.org/projects/fake-s3)
+to obtain a license key. For individual developers and small organizations,
+there is no cost. Add the following to a local `.env` file in the root
+of the project:
+
+    FAKES3_LICENSE_KEY=your-license-key-here
+
+Some of the unit tests actually test against Twitter itself, so you'll
+want to generate a custom Twitter app with your own set of keys.
+Configure the `test_settings` in your `settings.py` file appropriately:
 
     "twitter_consumer_key" : "twitter_consumer_key_here",
     "twitter_consumer_secret" : "twitter_consumer_secret_key_here",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,10 @@ services:
         aliases:
           - mltshp.localhost
   fakes3:
-    image: fingershock/fakes3
+    image: ourtownrentals/fake-s3
+    entrypoint: fakes3 -r /srv --license ${FAKES3_LICENSE_KEY} -p 8000
     volumes:
-      - ./mounts/fakes3:/fakes3_data
+      - ./mounts/fakes3:/srv
     networks:
       app_net:
         aliases:


### PR DESCRIPTION
Uses `ourtownrentals/fake-s3` instead of `fingershock/fakes3` now. Latest version now requires a license key for use (no cost, but has to be renewed periodically). README has been updated to document how to configure this new setting.