### PR TITLE
Fix issue with member not being removed from shake

### DIFF
--- a/templates/shakes/members.html
+++ b/templates/shakes/members.html
@@ -28,7 +28,7 @@
           </div>
           {% if shake.is_owner(current_user_object) %}
             <div  class="remove-from-shake-button">
-              <a class="btn btn-small btn-danger btn-pastel" href="">Remove From Shake</a>
+              <a class="remove-from-shake-button-link btn btn-small btn-danger btn-pastel" href="">Remove From Shake</a>
               <form  style="display: none;" action="/shake/{{escape(shake.name)}}/members/remove?user_id={{manager.id}}">
                 <input type="hidden" name="user_id" value="{{manager.id}}">
                 {{ xsrf_form_html() }}


### PR DESCRIPTION
Hey everyone,

I just wanted to share a quick update on my contribution to the project. After investigating the issue with members not being removed from the shake, I found that the members template was missing the "remove-from-shake-button-link" class in the anchor tag of the remove button. This was preventing managers from being properly removed from the shake.

 I recorded a short video showing how managers can now be removed from the shake without any issues:
 [Video of managers being removed](https://user-images.githubusercontent.com/25804457/236716658-0f46958a-9787-4824-b465-fac64bb70740.mov)


