### PR TITLE
remove best_of_mltshp Twitter

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -180,7 +180,6 @@
                     &nbsp; <a href="/terms-of-use">Terms of Use</a>
                     &nbsp; <a href="/code-of-conduct">Code of Conduct</a>
                     &nbsp; <a href="mailto:hello@mltshp.com">Contact Us</a>
-                    &nbsp; <a href="https://twitter.com/best_of_mltshp">@best_of_mltshp</a>
                 </p>
                 <p>
                     <a href="/user/mltshp">Follow The MLTSHP User!</a>


### PR DESCRIPTION
https://twitter.com/best_of_mltshp no longer updates, almost certainly due to Twitter's API changes, this removes the link from the footer