### PR TITLE
remove best_of_mltshp Twitter from FAQ

### DIFF
--- a/templates/misc/faq.html
+++ b/templates/misc/faq.html
@@ -117,8 +117,7 @@
       <p>
         Using some magic, the <a href="/user/mltshp">MLTSHP</a> user saves some of the best
         images from the site. You can access that RSS feed with <a href="/user/mltshp/rss">this link</a>
-        or follow <a href="https://twitter.com/best_of_mltshp">@Best_of_MLTSHP</a> on Twitter
-        or the <a href="https://mastodon.cloud/@best_of_mltshp@bird.makeup">@best_of_mltshp@bird.makeup bot</a> on Mastodon.
+        or follow the <a href="https://mastodon.cloud/@best_of_mltshp@bird.makeup">@best_of_mltshp@bird.makeup bot</a> on Mastodon.
       </p>
 
       <h2 id="twitter">How can I use MLTSHP to host photos I tweet to Twitter?</h2>


### PR DESCRIPTION
https://twitter.com/best_of_mltshp no longer updates, almost certainly due to Twitter's API changes, this removes the link from the FAQ