### PR TITLE
Fixing subscription search

### DIFF
--- a/models/sharedfile.py
+++ b/models/sharedfile.py
@@ -649,7 +649,7 @@ class Sharedfile(ModelQueryCache, Model):
 
         select_args = []
         if q is not None:
-            constraint_sql += " AND MATCH (sharedfile.title, sharedfile.description) AGAINST (%s IN BOOLEAN MODE)"
+            constraint_sql += " AND MATCH (sharedfile.title, sharedfile.description, sharedfile.alt_text) AGAINST (%s IN BOOLEAN MODE)"
             select_args.append(q)
 
         # We aren't joining on sharedfile using the deleted column since that

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pycurl==7.43.0
 pyparsing==2.2.0
 python-dateutil==1.5
 python-postmark==0.5.0
+python-slugify==5
 recaptcha-client==1.0.6
 tornado==4.1
 torndb==0.3


### PR DESCRIPTION
A small regression with the alt text support in subscription search. Adding the new column fixes the issue.

Also including a pinned python-slugify requirement, since yoyo doesn't pin it and version 6.something was installing in production and was unable to run under Python 2.7.