### PR TITLE
Alt text share fix

### DIFF
--- a/models/sharedfile.py
+++ b/models/sharedfile.py
@@ -232,6 +232,7 @@ class Sharedfile(ModelQueryCache, Model):
         new_sharedfile.source_id = self.source_id
         new_sharedfile.parent_id = self.id
         new_sharedfile.description = self.description
+        new_sharedfile.alt_text = self.alt_text
 
         if self.original_id == 0:
             new_sharedfile.original_id = self.id

--- a/test/functional/image_save_tests.py
+++ b/test/functional/image_save_tests.py
@@ -27,7 +27,7 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         self.jim = User(name='jim', email='jim@mltshp.com', email_confirmed=0, is_paid=1)
         self.jim.set_password('asdfasdf')
         self.jim.save()
-        
+
         # uploader's file.
         self.sharedfile = self._create_sharedfile(self.admin)
 
@@ -39,35 +39,35 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         sourcefile.save()
         sharedfile = Sharedfile(source_id=sourcefile.id, name="the name",user_id=user.id, \
             content_type="image/png", title='the title', description="the description", \
-            source_url="https://www.mltshp.com/?hi")
+            alt_text="the alt text", source_url="https://www.mltshp.com/?hi")
         sharedfile.save()
         sharedfile.share_key = lib.utilities.base36encode(sharedfile.id)
         sharedfile.save()
         return sharedfile
-    
+
     def test_non_authenticated_save_returns_403(self):
         response = self.post_url('/p/%s/save' % self.sharedfile.share_key)
         self.assertEqual(403, response.code)
-    
+
     def test_saving_non_existant_file_returns_404(self):
         self.sign_in('bob', 'asdfasdf')
         response = self.post_url('/p/admin3000/save')
         self.assertEqual(404, response.code)
-    
+
     def test_saving_file_response(self):
         """
-        Saving a file should redirect to the new file URL, unless json=1 is 
+        Saving a file should redirect to the new file URL, unless json=1 is
         passed in. In which case response should contain original share_key,
         new_share_key and count.
-        
+
         Test is a bit fragile because it assume we only have only the original
         shared file to start.
         """
         self.sign_in('bob', 'asdfasdf')
         response = self.post_url('/p/%s/save' % self.sharedfile.share_key)
-        self.assertEqual(200, response.code)        
+        self.assertEqual(200, response.code)
         self.assertEqual('/p/2', urlparse(response.effective_url).path)
-        
+
         arguments = {'json' : 1}
         response = self.post_url('/p/%s/save' % self.sharedfile.share_key, arguments=arguments)
         self.assertEqual(200, response.code)
@@ -76,28 +76,28 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         self.assertEqual('3', json_response['new_share_key'])
         self.assertEqual(self.sharedfile.share_key, json_response['share_key'])
         self.assertEqual(2, json_response['count'])
-    
+
     def test_saving_original_file_populates_parent_id_original_id_correctly(self):
         """
         Bob should be able to save admin's original file.  The parent_id should
         point to admin's file and so should original_id.
-        
+
         Tom can save bob's file.  Tom's parent_id will be bobs file, while the
         original id will be admin's file.
         """
         #bob saves admin's original file
         self.sign_in("bob", "asdfasdf")
         response = self.post_url('/p/%s/save' % self.sharedfile.share_key)
-        
+
         #bob's saves file points to admin's shared file as the parent and admin's shared file as the original id
-        bobs_file = Sharedfile.get("share_key= %s and user_id = %s", 2, self.bob.id)        
+        bobs_file = Sharedfile.get("share_key= %s and user_id = %s", 2, self.bob.id)
         self.assertEqual(bobs_file.parent_id, self.sharedfile.id)
         self.assertEqual(bobs_file.original_id, self.sharedfile.id)
-        
+
         #tom saves bob's file
         self.sign_in("tom", "asdfasdf")
         response = self.post_url('/p/%s/save' % bobs_file.share_key)
-        
+
         #tom's saves file points to bob's as the parent and admin's shared file as the original id
         toms_file = Sharedfile.get("share_key=%s and user_id = %s", 3, self.tom.id)
         self.assertEqual(toms_file.parent_id, bobs_file.id)
@@ -106,7 +106,7 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
     def test_saving_file_creates_shakesharedfile(self):
         """
         When bob saves admin's original file, an entry gets created in Shakesharedfile.
-        
+
         We assume file that gets saved has id of 2.
         """
         self.sign_in("bob", "asdfasdf")
@@ -147,11 +147,11 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         self.assertEqual(notifications[0].receiver_id, self.admin.id)
         self.assertEqual(notifications[0].action_id, self.sharedfile.id)
         self.assertEqual(notifications[0].type, 'save')
-        
-    def test_saving_file_copies_title_and_source_url_and_description(self):
+
+    def test_saving_file_copies_title_and_source_url_description_and_alt_text(self):
         """
         Saving sharedfile should transfer over the title, description and source fields.
-        
+
         Assume only one file to begin with.
         """
         sid = self.sign_in("bob", "asdfasdf")
@@ -160,4 +160,4 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         self.assertEqual(sharedfile.source_url, 'https://www.mltshp.com/?hi')
         self.assertEqual(sharedfile.title, 'the title')
         self.assertEqual(sharedfile.description, 'the description')
-
+        self.assertEqual(sharedfile.alt_text, 'the alt text')


### PR DESCRIPTION
Re: #715 this copies the `alt_text` of a sharedfile when it's getting re-saved to a new shake. My text editor has applied some opinionated changes to whitespace in the test file, I can remove those edits if it's annoying.