### PR TITLE
Fixing a race condition affecting sign-up form

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1175,8 +1175,10 @@ $(document).ready(function() {
       });
     });
 
-    /* Action Button in a Fun Form, should submit the form */
-    $(".field-submit .btn").click(function() {
+    /* Action Button in a Fun Form, should submit the form (exception here
+       for a button with a g-recaptcha class which has a separate event
+       handler). */
+    $(".field-submit .btn:not(.g-recaptcha)").click(function() {
       $(this).closest("form").submit();
       return false;
     })


### PR DESCRIPTION
In some cases, the submit button sends the sign-up request ahead of the reCaptcha token request.