### PR TITLE
Update cool tools

### DIFF
--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -98,11 +98,7 @@
         <li class="safari"><a href="/static/plugins/mltshp.safari.safariextz">Safari Extension</a></li>
         <li class="firefox"><a href="/static/plugins/mltshp.firefox.xpi">Firefox Add-On</a></li>
         <li class="chrome"><a href="https://chrome.google.com/webstore/detail/mltshp/dpkfhblfcdhcdekliknbpekjcppgihcd">Chrome Extension</a></li>
-
       </ul>
-      {% if not site_is_readonly %}
-      <a class="twitter-setup" href="/tools/twitter">Set up your phone for Twitter</a>
-      {% end %}
     </div>
   </div>
   <div class="body">

--- a/templates/tools/plugins.html
+++ b/templates/tools/plugins.html
@@ -10,7 +10,7 @@
         <a href="/static/plugins/mltshp.safari.safariextz"><img src="{{ static_url("images/safari-icon.png") }}" width="48" height="48" align="center"></a> <a href="/static/plugins/mltshp.safari.safariextz">Safari Extension</a>
     </p>
     <p>
-        <a href="/static/plugins/mltshp.firefox.xpi"><img src="{{ static_url("images/firefox-icon.png") }}" width="48" height="48" align="center"></a> <a href="/static/plugins/mltshp.firefox.xpi">Firefox Add-On</a>
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/mltshp2/"><img src="{{ static_url("images/firefox-icon.png") }}" width="48" height="48" align="center"></a> <a href="https://addons.mozilla.org/en-US/firefox/addon/mltshp2/">Firefox Add-On</a>
     </p>
     <p>
         <a href="https://chrome.google.com/webstore/detail/mltshp/dpkfhblfcdhcdekliknbpekjcppgihcd"><img src="{{ static_url("images/chrome-icon.png") }}" width="48" height="48" align="center"></a> <a href="https://chrome.google.com/webstore/detail/mltshp/dpkfhblfcdhcdekliknbpekjcppgihcd">Chrome Extension</a>


### PR DESCRIPTION
1. Changes Firefox plugin link to `https://addons.mozilla.org/en-US/firefox/addon/mltshp2/`
2. Removes “Set up your phone for Twitter”