### PR TITLE
Whitespace cleanup: Format Javascript #354 Review

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+static/straw/compact.js
+static/js/jquery-min-1.4.2.js

--- a/static/js/bookmarklet.js
+++ b/static/js/bookmarklet.js
@@ -1,15 +1,16 @@
 function straw() {
     this.morsels = new Array();
     this.id = 0;
-  
-    this.init = function(){
-        var head = document.getElementsByTagName('head')[0],
-        style = document.createElement('style'),
-        rules = document.createTextNode('div#mltshp_container div.chum_overlay{border:10px solid #ede500;cursor:pointer;font-family:Arial,Helvetica,sans-serif;font-size:16px;font-weight:bold;padding:10px;position:absolute;z-index:5000000;}\ndiv#mltshp_container div.chum_overlay div{background:#ede500;color:#000;padding:10px;text-align:center;}\ndiv#mltshp_container div.chum_overlay:hover{border:10px solid #f6ff00;}\ndiv#mltshp_container div.chum_overlay div:hover{background:#f6ff00;}');
-        style.type = 'text/css';
 
-        if(style.styleSheet)
-        {
+    this.init = function () {
+        var head = document.getElementsByTagName("head")[0],
+            style = document.createElement("style"),
+            rules = document.createTextNode(
+                "div#mltshp_container div.chum_overlay{border:10px solid #ede500;cursor:pointer;font-family:Arial,Helvetica,sans-serif;font-size:16px;font-weight:bold;padding:10px;position:absolute;z-index:5000000;}\ndiv#mltshp_container div.chum_overlay div{background:#ede500;color:#000;padding:10px;text-align:center;}\ndiv#mltshp_container div.chum_overlay:hover{border:10px solid #f6ff00;}\ndiv#mltshp_container div.chum_overlay div:hover{background:#f6ff00;}",
+            );
+        style.type = "text/css";
+
+        if (style.styleSheet) {
             style.styleSheet.cssText = rules.nodeValue;
         } else {
             style.appendChild(rules);
@@ -22,81 +23,111 @@ function straw() {
         document.getElementsByTagName("body")[0].appendChild(container);
         document.getElementById("mltshp_container").style.display = "none";
         this.chum_chum();
-    }
+    };
 
-    this.chum_chum = function(){
-      
+    this.chum_chum = function () {
         // first they came for the images
         var images = document.getElementsByTagName("img");
-        for(var i = 0;i<images.length;i++){
+        for (var i = 0; i < images.length; i++) {
             var image = images[i];
 
-            if (image.offsetWidth >= 100 && image.offsetHeight >= 100 && image.src != ''){
+            if (
+                image.offsetWidth >= 100 &&
+                image.offsetHeight >= 100 &&
+                image.src != ""
+            ) {
                 var width = image.offsetWidth;
                 var height = image.offsetHeight;
                 var pos = this.media_location(image);
-                this.create_overlay('image', width, height, pos, this.id, image.src);
+                this.create_overlay(
+                    "image",
+                    width,
+                    height,
+                    pos,
+                    this.id,
+                    image.src,
+                );
             }
             this.id++;
         }
-      
+
         // then they came for the youtube videos
         //if (document.domain == "youtube.com" || document.domain == "localhost" || document.domain == "www.youtube.com"){
-        if (false){
-            player_holder = document.getElementById('watch-player');
+        if (false) {
+            player_holder = document.getElementById("watch-player");
             nodes = player_holder.childNodes;
-            for(var k=0;k<nodes.length;k++){
-                this_node = nodes[k]
-                if((this_node.nodeName) === "IFRAME"){
+            for (var k = 0; k < nodes.length; k++) {
+                this_node = nodes[k];
+                if (this_node.nodeName === "IFRAME") {
                     var width = this_node.offsetWidth;
                     var height = this_node.offsetHeight;
                     var pos = this.media_location(this_node);
-                    this.create_overlay('video', width, height, pos, this.id, location.href);
+                    this.create_overlay(
+                        "video",
+                        width,
+                        height,
+                        pos,
+                        this.id,
+                        location.href,
+                    );
                     this.id++;
                     break;
                 }
             }
         }
-        
+
         // then they came for the vimeo videos
         //if (document.domain == "vimeo.com" || document.domain == "localhost" || document.domain == "www.vimeo.com"){
-        if (false){
-            possible_players = document.getElementsByTagName('div');
+        if (false) {
+            possible_players = document.getElementsByTagName("div");
 
-            for(var j = 0;j<possible_players.length;j++){
-                if(typeof(possible_players[j]) === "object"){
-                    if(possible_players[j].className == "vimeo_holder"){
+            for (var j = 0; j < possible_players.length; j++) {
+                if (typeof possible_players[j] === "object") {
+                    if (possible_players[j].className == "vimeo_holder") {
                         var width = possible_players[i].offsetWidth;
                         var height = possible_players[i].offsetHeight;
                         var pos = this.media_location(possible_players[j]);
-                        this.create_overlay('video', width, height, pos, this.id, location.href);
+                        this.create_overlay(
+                            "video",
+                            width,
+                            height,
+                            pos,
+                            this.id,
+                            location.href,
+                        );
                         this.id++;
                     }
                 }
             }
-            
         }
-    }
-  
-    this.create_overlay = function(type, width, height, pos, obj_id, url){
+    };
+
+    this.create_overlay = function (type, width, height, pos, obj_id, url) {
         var overlay = document.createElement("div");
         overlay.id = "chum_overlay_" + obj_id;
         overlay.setAttribute("class", "chum_overlay");
         overlay.style.display = "block";
-        overlay.style.width = (width - 40) + "px";
-        overlay.style.height = (height - 40) + "px";
+        overlay.style.width = width - 40 + "px";
+        overlay.style.height = height - 40 + "px";
         overlay.style.left = pos[0] + "px";
         overlay.style.top = pos[1] + "px";
-        overlay.innerHTML = "<div id='chum_inner_" + obj_id + "'>save this " + type + "</div>";
-        if(type == "image"){
-            overlay.setAttribute("onclick", "straw.select_image('" + url + "')");
-        } else if(type=="video"){
-            overlay.setAttribute("onclick", "straw.select_video('" + url + "')");
+        overlay.innerHTML =
+            "<div id='chum_inner_" + obj_id + "'>save this " + type + "</div>";
+        if (type == "image") {
+            overlay.setAttribute(
+                "onclick",
+                "straw.select_image('" + url + "')",
+            );
+        } else if (type == "video") {
+            overlay.setAttribute(
+                "onclick",
+                "straw.select_video('" + url + "')",
+            );
         }
         document.getElementById("mltshp_container").appendChild(overlay);
-    }
-  
-    this.media_location = function(media_object){
+    };
+
+    this.media_location = function (media_object) {
         var x = media_object.offsetLeft;
         var y = media_object.offsetTop;
 
@@ -111,32 +142,47 @@ function straw() {
             }
         }
         return [x, y];
-    }
+    };
 
-    this.select_image = function(image_url){
+    this.select_image = function (image_url) {
         //open a new window
-        //location is 
-        left_location = screen.width/2-450;
-        top_location = screen.height/2-300;
-        var window_attributes = "width=850,height=650,menubar=yes,toolbar=yes,scrollbars=yes,resizable=yes,left=" + left_location + ",top=" + top_location + "screenX=" + left_location + ",screenY=" + top_location;
-        window.open('https://mltshp.com/tools/p?url=' + escape(image_url) + '&source_url=' + escape(location.href) ,'save image',window_attributes);
-    }
+        //location is
+        left_location = screen.width / 2 - 450;
+        top_location = screen.height / 2 - 300;
+        var window_attributes =
+            "width=850,height=650,menubar=yes,toolbar=yes,scrollbars=yes,resizable=yes,left=" +
+            left_location +
+            ",top=" +
+            top_location +
+            "screenX=" +
+            left_location +
+            ",screenY=" +
+            top_location;
+        window.open(
+            "https://mltshp.com/tools/p?url=" +
+                escape(image_url) +
+                "&source_url=" +
+                escape(location.href),
+            "save image",
+            window_attributes,
+        );
+    };
 
-    this.select_video = function(video_url){
+    this.select_video = function (video_url) {
         console.log(video_url);
-    }
+    };
 
-  this.init();
-  document.getElementById("mltshp_container").style.display = "block";
+    this.init();
+    document.getElementById("mltshp_container").style.display = "block";
 }
 
-if(!window.straw_running) {
+if (!window.straw_running) {
     window.straw_running = true;
     var straw = new straw();
 } else {
     document.getElementById("mltshp_container").style.display = "none";
     window.straw_running = false;
-    d = document.getElementsByTagName("body")[0]
-    dd = document.getElementById('mltshp_container');
+    d = document.getElementsByTagName("body")[0];
+    dd = document.getElementById("mltshp_container");
     d.removeChild(dd);
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,1723 +1,2118 @@
 /* For now the core JS behavior needed accross the site */
 
-$(document).ready(function() {
+$(document).ready(function () {
+    var NewPostPanel = (function () {
+        var panel_expanded = false;
 
+        var $new_post_panel;
+        var $new_post_panel_inner;
+        var $new_post_button;
+        var $save_video_form;
+        var $save_video_form_button;
+        var $post_video_form;
+        var $post_video_form_button;
 
-    var NewPostPanel = function() {
-      var panel_expanded = false;
+        var init_dom = function () {
+            $new_post_panel = $("#new-post-panel");
+            $new_post_panel_inner = $("#new-post-panel .new-post-panel--inner");
+            $new_post_button = $("#new-post-button");
+            // upload image
+            $upload_image_input = $("#upload-image-input");
+            // link to video
+            $link_to_video = $("#link-to-video");
+            $video_shake_id = $("#video-shake-id");
+            // video preview screen
+            $save_video_form = $("#new-post-panel .save-video-form");
+            $save_video_form_button = $(
+                "#new-post-panel .save-video-form .btn",
+            );
+            $post_video_form = $("#new-post-panel .post-video-form");
+            $post_video_form_button = $(
+                "#new-post-panel .post-video-form .btn",
+            );
+            // shake selector
+            $shake_selector = $(".shake-selector");
+        };
+        init_dom();
 
-      var $new_post_panel;
-      var $new_post_panel_inner;
-      var $new_post_button;
-      var $save_video_form;
-      var $save_video_form_button;
-      var $post_video_form;
-      var $post_video_form_button;
-
-      var init_dom = function() {
-        $new_post_panel = $("#new-post-panel");
-        $new_post_panel_inner = $("#new-post-panel .new-post-panel--inner");
-        $new_post_button = $("#new-post-button");
-        // upload image
-        $upload_image_input = $("#upload-image-input");
-        // link to video
-        $link_to_video = $("#link-to-video");
-        $video_shake_id = $("#video-shake-id");
-        // video preview screen
-        $save_video_form = $("#new-post-panel .save-video-form");
-        $save_video_form_button = $("#new-post-panel .save-video-form .btn");
-        $post_video_form = $("#new-post-panel .post-video-form");
-        $post_video_form_button = $("#new-post-panel .post-video-form .btn");
-        // shake selector
-        $shake_selector = $(".shake-selector");
-      };
-      init_dom();
-
-      $new_post_button.click(function() {
-        NewPostPanel.load_new_post();
-        return false;
-      });
-
-      // We don't want click event on panel to bubble up to body
-      // since a click to body closes the panel.
-      $new_post_panel.click(function(ev) {
-        ev.stopPropagation();
-      });
-
-      // The events that are inside the panel that we want to initialize
-      // when the panel loads.  These are the events that are subject
-      // to change depending on content that is loaded.
-      var init_events = function() {
-        $link_to_video.click(function() {
-          NewPostPanel.load_post_video();
-          return false;
+        $new_post_button.click(function () {
+            NewPostPanel.load_new_post();
+            return false;
         });
 
-        $save_video_form_button.click(function(e) {
-          NewPostPanel.submit_save_video();
-          return false;
+        // We don't want click event on panel to bubble up to body
+        // since a click to body closes the panel.
+        $new_post_panel.click(function (ev) {
+            ev.stopPropagation();
         });
 
-        $post_video_form_button.click(function(e) {
-          NewPostPanel.submit_post_video();
-          return false;
-        });
+        // The events that are inside the panel that we want to initialize
+        // when the panel loads.  These are the events that are subject
+        // to change depending on content that is loaded.
+        var init_events = function () {
+            $link_to_video.click(function () {
+                NewPostPanel.load_post_video();
+                return false;
+            });
 
-        $upload_image_input.change(function() {
-          $(this).closest('form').submit();
-        });
+            $save_video_form_button.click(function (e) {
+                NewPostPanel.submit_save_video();
+                return false;
+            });
 
-        $shake_selector.click(NewPostPanel.toggle_shake_selector);
-        $shake_selector.find('ul a').click(NewPostPanel.choose_shake);
-      };
+            $post_video_form_button.click(function (e) {
+                NewPostPanel.submit_post_video();
+                return false;
+            });
 
-      var remove_events = function() {
-        $save_video_form_button.unbind();
-        $post_video_form_button.unbind();
-        $shake_selector.unbind();
-        $link_to_video.unbind();
-      };
+            $upload_image_input.change(function () {
+                $(this).closest("form").submit();
+            });
 
-      return {
-        toggle_shake_selector: function(ev) {
-          $(this).toggleClass('is-active').find('ul').toggle();
-          ev.stopPropagation();
-          ev.preventDefault();
-        },
-        // Sets the text of the shake to the chosen one and
-        // sets a hidden input field with the proper shake id.
-        choose_shake: function() {
-          var $shake_selector = $(this).parents('.shake-selector');
-          var $selected_shake = $shake_selector.find('.green');
-          var $selected_shake_input = $shake_selector.find('input');
-          var name = $(this).html();
-          var id = $(this).attr('id').replace(/[^0-9]+/, '');
-          $selected_shake.html(name);
-          $selected_shake_input.val(id);
-        },
-        load_new_post: function() {
-          var url = '/tools/new-post';
-          var that = this;
-          $.get(url, function(response) {
-            that.refresh_panel(response);
-            that.expand_panel();
-          });
-          return false;
-        },
-        load_post_video: function() {
-          if ($video_shake_id.length > 0) {
-            var shake_suffix = "?shake_id=" + $video_shake_id.val();
-          } else {
-            var shake_suffix = "";
-          }
-          var url = '/tools/save-video' + shake_suffix;
-          var that = this;
-          $.get(url, function(response) {
-            that.refresh_panel(response);
-            that.expand_panel();
-          });
-        },
-        expand_panel: function() {
-          panel_expanded = true;
-          $new_post_panel.slideDown();
-          that = this;
-          $('body').one('click', $.proxy(this.close_panel, this));
-          // we want to hide anything with a video since we can't
-          // overlap things like youtube embeds, which is an iframe
-          // that has an absolutely positioned flash element inside.
-          $('.the-image iframe').each(function() {
-            $(this).parent().css('height', $(this).height());
-            $(this).parent().css('width', $(this).width());
-            $(this).hide();
-          });
-        },
-        close_panel: function() {
-          panel_expanded = false;
-          $new_post_panel.hide();
-          remove_events();
-          // show the videos again.
-          $('.the-image iframe').show();
-        },
-        submit_save_video: function() {
-          var url = $save_video_form.attr('action');
-          var data = $save_video_form.serialize();
-          var that = this;
-          $.get(url, data, function(response) {
-            that.refresh_panel(response);
-          });
-        },
-        submit_post_video: function() {
-          var url = $post_video_form.attr('action');
-          var data = $post_video_form.serialize();
-          var that = this;
-          $post_video_form_button.unbind('click').find('span').html('Posting...');
-          $.post(url, data, function(response) {
-            document.location = document.location.protocol + '//' + document.location.host + response['path'];
-          }, 'json');
-        },
-        refresh_panel: function(response) {
-          $new_post_panel_inner.html(response);
-          $new_post_panel_inner.html();
-          remove_events();
-          init_dom();
-          init_events();
-        }
-      }
-    }();
+            $shake_selector.click(NewPostPanel.toggle_shake_selector);
+            $shake_selector.find("ul a").click(NewPostPanel.choose_shake);
+        };
 
-    var to_text = function(num, base) {
-      return (num == 1) ? num + ' ' + "<span>" + base + "</span>" : num + ' ' + "<span>" + base + 's' + "</span>";
-    }
+        var remove_events = function () {
+            $save_video_form_button.unbind();
+            $post_video_form_button.unbind();
+            $shake_selector.unbind();
+            $link_to_video.unbind();
+        };
 
-    var ShakesCache = {
-      fetch: function() {
-        if (this.result !== undefined) {
-          return this.result;
-        } else {
-          return false;
-        }
-      },
+        return {
+            toggle_shake_selector: function (ev) {
+                $(this).toggleClass("is-active").find("ul").toggle();
+                ev.stopPropagation();
+                ev.preventDefault();
+            },
+            // Sets the text of the shake to the chosen one and
+            // sets a hidden input field with the proper shake id.
+            choose_shake: function () {
+                var $shake_selector = $(this).parents(".shake-selector");
+                var $selected_shake = $shake_selector.find(".green");
+                var $selected_shake_input = $shake_selector.find("input");
+                var name = $(this).html();
+                var id = $(this)
+                    .attr("id")
+                    .replace(/[^0-9]+/, "");
+                $selected_shake.html(name);
+                $selected_shake_input.val(id);
+            },
+            load_new_post: function () {
+                var url = "/tools/new-post";
+                var that = this;
+                $.get(url, function (response) {
+                    that.refresh_panel(response);
+                    that.expand_panel();
+                });
+                return false;
+            },
+            load_post_video: function () {
+                if ($video_shake_id.length > 0) {
+                    var shake_suffix = "?shake_id=" + $video_shake_id.val();
+                } else {
+                    var shake_suffix = "";
+                }
+                var url = "/tools/save-video" + shake_suffix;
+                var that = this;
+                $.get(url, function (response) {
+                    that.refresh_panel(response);
+                    that.expand_panel();
+                });
+            },
+            expand_panel: function () {
+                panel_expanded = true;
+                $new_post_panel.slideDown();
+                that = this;
+                $("body").one("click", $.proxy(this.close_panel, this));
+                // we want to hide anything with a video since we can't
+                // overlap things like youtube embeds, which is an iframe
+                // that has an absolutely positioned flash element inside.
+                $(".the-image iframe").each(function () {
+                    $(this).parent().css("height", $(this).height());
+                    $(this).parent().css("width", $(this).width());
+                    $(this).hide();
+                });
+            },
+            close_panel: function () {
+                panel_expanded = false;
+                $new_post_panel.hide();
+                remove_events();
+                // show the videos again.
+                $(".the-image iframe").show();
+            },
+            submit_save_video: function () {
+                var url = $save_video_form.attr("action");
+                var data = $save_video_form.serialize();
+                var that = this;
+                $.get(url, data, function (response) {
+                    that.refresh_panel(response);
+                });
+            },
+            submit_post_video: function () {
+                var url = $post_video_form.attr("action");
+                var data = $post_video_form.serialize();
+                var that = this;
+                $post_video_form_button
+                    .unbind("click")
+                    .find("span")
+                    .html("Posting...");
+                $.post(
+                    url,
+                    data,
+                    function (response) {
+                        document.location =
+                            document.location.protocol +
+                            "//" +
+                            document.location.host +
+                            response["path"];
+                    },
+                    "json",
+                );
+            },
+            refresh_panel: function (response) {
+                $new_post_panel_inner.html(response);
+                $new_post_panel_inner.html();
+                remove_events();
+                init_dom();
+                init_events();
+            },
+        };
+    })();
 
-      store: function(result) {
-        this.result = result;
-      }
+    var to_text = function (num, base) {
+        return num == 1
+            ? num + " " + "<span>" + base + "</span>"
+            : num + " " + "<span>" + base + "s" + "</span>";
     };
 
-    var SaveThisView = function(container) {
-      this.$save_this = $(container);
-      this.init();
+    var ShakesCache = {
+        fetch: function () {
+            if (this.result !== undefined) {
+                return this.result;
+            } else {
+                return false;
+            }
+        },
+
+        store: function (result) {
+            this.result = result;
+        },
+    };
+
+    var SaveThisView = function (container) {
+        this.$save_this = $(container);
+        this.init();
     };
 
     $.extend(SaveThisView.prototype, {
-      init: function() {
-        this.init_dom();
-        this.init_events();
-      },
+        init: function () {
+            this.init_dom();
+            this.init_events();
+        },
 
-      init_dom: function() {
-        this.$save_this_link = this.$save_this.find('.save-this-link');
-        this.$form = this.$save_this.find('form');
-        this.$shake_id_input = this.$save_this.find('.shake-id-input');
-        this.$shake_selector = $("<div class='save-this-shake-selector save-this-shake-selector-loading'></div>");
-      },
+        init_dom: function () {
+            this.$save_this_link = this.$save_this.find(".save-this-link");
+            this.$form = this.$save_this.find("form");
+            this.$shake_id_input = this.$save_this.find(".shake-id-input");
+            this.$shake_selector = $(
+                "<div class='save-this-shake-selector save-this-shake-selector-loading'></div>",
+            );
+        },
 
-      init_events: function() {
-        this.$save_this_link.click($.proxy(this.click_save_this, this));
-        this.$save_this.delegate('.shake-link', 'click', $.proxy(this.click_choose_shake, this));
-        this.$save_this.delegate('.close', 'click', $.proxy(this.click_close_selector, this));
-      },
+        init_events: function () {
+            this.$save_this_link.click($.proxy(this.click_save_this, this));
+            this.$save_this.delegate(
+                ".shake-link",
+                "click",
+                $.proxy(this.click_choose_shake, this),
+            );
+            this.$save_this.delegate(
+                ".close",
+                "click",
+                $.proxy(this.click_close_selector, this),
+            );
+        },
 
-      click_save_this: function(ev) {
-        ev.stopPropagation();
-        if (this.$save_this_link.hasClass('save-this-link-multiple')) {
-          this.show_shake_selector();
-        } else {
-          this.submit_image_save();
-        }
-        return false;
-      },
+        click_save_this: function (ev) {
+            ev.stopPropagation();
+            if (this.$save_this_link.hasClass("save-this-link-multiple")) {
+                this.show_shake_selector();
+            } else {
+                this.submit_image_save();
+            }
+            return false;
+        },
 
-      click_choose_shake: function(ev) {
-        ev.stopPropagation();
-        var shake_id = ev.target.id.replace(/[^\d]+/, '');
-        this.$shake_id_input.val(shake_id);
-        this.submit_image_save();
-        return false;
-      },
+        click_choose_shake: function (ev) {
+            ev.stopPropagation();
+            var shake_id = ev.target.id.replace(/[^\d]+/, "");
+            this.$shake_id_input.val(shake_id);
+            this.submit_image_save();
+            return false;
+        },
 
-      click_close_selector: function(ev) {
-        ev.stopPropagation();
-        this.$shake_selector.remove();
-      },
+        click_close_selector: function (ev) {
+            ev.stopPropagation();
+            this.$shake_selector.remove();
+        },
 
-      show_shake_selector: function() {
-        this.$save_this.append(this.$shake_selector);
-        $('body').one('click', $.proxy(this.click_close_selector, this));
+        show_shake_selector: function () {
+            this.$save_this.append(this.$shake_selector);
+            $("body").one("click", $.proxy(this.click_close_selector, this));
 
-        // Only query once per page.
-        if (ShakesCache.fetch() !== false) {
-          this.fetch_available_shakes(ShakesCache.fetch());
-        } else {
-           $.get('/account/shakes', $.proxy(this.fetch_available_shakes, this), 'json');
-        }
-      },
+            // Only query once per page.
+            if (ShakesCache.fetch() !== false) {
+                this.fetch_available_shakes(ShakesCache.fetch());
+            } else {
+                $.get(
+                    "/account/shakes",
+                    $.proxy(this.fetch_available_shakes, this),
+                    "json",
+                );
+            }
+        },
 
-      fetch_available_shakes: function(response) {
-        ShakesCache.store(response);
-        var html = '<span class="close caret"></span><ul>';
-        for (var i = 0; i < response['result'].length; i++) {
-          html += '<li><a class="shake-link" href="" id="save-this-shake-selector-' +
-                  response['result'][i]['id'] + '">'+
-                  response['result'][i]['name'] +
-                  '</a></li>';
-        }
-        html += '</ul>';
-        this.$shake_selector.removeClass('save-this-shake-selector-loading').html(html);
-      },
+        fetch_available_shakes: function (response) {
+            ShakesCache.store(response);
+            var html = '<span class="close caret"></span><ul>';
+            for (var i = 0; i < response["result"].length; i++) {
+                html +=
+                    '<li><a class="shake-link" href="" id="save-this-shake-selector-' +
+                    response["result"][i]["id"] +
+                    '">' +
+                    response["result"][i]["name"] +
+                    "</a></li>";
+            }
+            html += "</ul>";
+            this.$shake_selector
+                .removeClass("save-this-shake-selector-loading")
+                .html(html);
+        },
 
-      submit_image_save: function(ev) {
-        var url = this.$form.attr('action');
-        var data = this.$form.serialize();
-        $.post(url, data, $.proxy(this.process_image_save_response, this), 'json');
-      },
+        submit_image_save: function (ev) {
+            var url = this.$form.attr("action");
+            var data = this.$form.serialize();
+            $.post(
+                url,
+                data,
+                $.proxy(this.process_image_save_response, this),
+                "json",
+            );
+        },
 
-      process_image_save_response: function(response) {
-        if (response['share_key']) {
-          var count = response['count'];
-          var share_key = response['share_key'];
-          var new_share_key = response['new_share_key'];
-          var count_string = to_text(count, "Save");
-          $("#save-count-amount-" + share_key).html(count_string);
-          var output = '<a href="/p/' + new_share_key + '" title="Saved It!"><img width="29" height="22" src="/static/images/saved-this.svg"></a>';
-          this.$shake_selector.remove();
-          this.$save_this.html(output);
-          SidebarStatsView.refresh_saves();
-          StreamStatsViewRegistry.refresh_saves(share_key);
-        } else {
-          return false;
-        }
-      }
+        process_image_save_response: function (response) {
+            if (response["share_key"]) {
+                var count = response["count"];
+                var share_key = response["share_key"];
+                var new_share_key = response["new_share_key"];
+                var count_string = to_text(count, "Save");
+                $("#save-count-amount-" + share_key).html(count_string);
+                var output =
+                    '<a href="/p/' +
+                    new_share_key +
+                    '" title="Saved It!"><img width="29" height="22" src="/static/images/saved-this.svg"></a>';
+                this.$shake_selector.remove();
+                this.$save_this.html(output);
+                SidebarStatsView.refresh_saves();
+                StreamStatsViewRegistry.refresh_saves(share_key);
+            } else {
+                return false;
+            }
+        },
     });
 
     function screen_reader_focus(el) {
-      el.setAttribute('tabindex', '0');
-      el.blur();
-      el.focus();
+        el.setAttribute("tabindex", "0");
+        el.blur();
+        el.focus();
     }
 
-    $(".save-this").each(function() {
-      var save_this_view = new SaveThisView(this);
+    $(".save-this").each(function () {
+        var save_this_view = new SaveThisView(this);
     });
 
     // when we hit enter on a form, we want to submit it
     // even though we don't have an type="submit" input
     // available, since we're using a styled button.
     $sign_in_form = $("#sign-in-form");
-    $("input", $sign_in_form).keydown(function(e) {
-      if (e.keyCode == 13) {
-        $sign_in_form.submit();
-        return false;
-      }
+    $("input", $sign_in_form).keydown(function (e) {
+        if (e.keyCode == 13) {
+            $sign_in_form.submit();
+            return false;
+        }
     });
 
-    $(".btn", $sign_in_form).click(function() {
-      $sign_in_form.submit();
-      return false;
+    $(".btn", $sign_in_form).click(function () {
+        $sign_in_form.submit();
+        return false;
     });
 
     // Prompt user to confirm before flagging something as NSFW.
-    $("#flag-image-permalink").click(function() {
-      return confirm("Are you sure you want to flag this as NSFW?");
+    $("#flag-image-permalink").click(function () {
+        return confirm("Are you sure you want to flag this as NSFW?");
     });
 
     // Prompt user to confirm before quitting a shake.
-    $("#quit-shake-page").click(function() {
-      return confirm("Are you sure you want to quit this shake?\n(If you are following this shake you will also have to unfollow with the button above.)");
+    $("#quit-shake-page").click(function () {
+        return confirm(
+            "Are you sure you want to quit this shake?\n(If you are following this shake you will also have to unfollow with the button above.)",
+        );
     });
 
     // Prompt user to confirm before deleting a sharedfile.
-    $("#delete-post-text").click(function() {
-      return confirm("Are you sure you want to delete this post?");
+    $("#delete-post-text").click(function () {
+        return confirm("Are you sure you want to delete this post?");
     });
 
     // Inline editing of the title.
-    $(".image-edit-title-form .cancel").click(function() {
-      $(this).closest('.image-title').find(".image-edit-title").show();
-      $(this).closest(".image-edit-title-form").removeClass('is-active');
-      return false;
+    $(".image-edit-title-form .cancel").click(function () {
+        $(this).closest(".image-title").find(".image-edit-title").show();
+        $(this).closest(".image-edit-title-form").removeClass("is-active");
+        return false;
     });
 
-    $(".image-edit-title").hover(function() {
-      $(this).addClass('image-edit-title-hover');
-    }, function() {
-      $(this).removeClass('image-edit-title-hover');
+    $(".image-edit-title").hover(
+        function () {
+            $(this).addClass("image-edit-title-hover");
+        },
+        function () {
+            $(this).removeClass("image-edit-title-hover");
+        },
+    );
+
+    $(".image-edit-title").click(function () {
+        var $title_container = $(this).closest(".image-title");
+        var url = $title_container.find("form").attr("action");
+        var that = this;
+
+        $.get(
+            url,
+            function (result) {
+                if ("title_raw" in result) {
+                    $(that).hide();
+                    $title_container
+                        .find(".title-input")
+                        .val(result["title_raw"]);
+                    $(that)
+                        .next(".image-edit-title-form")
+                        .addClass("is-active");
+                }
+            },
+            "json",
+        );
     });
 
-    $(".image-edit-title").click(function() {
-      var $title_container = $(this).closest('.image-title');
-      var url = $title_container.find('form').attr('action');
-      var that = this;
-
-      $.get(url, function(result) {
-        if ('title_raw' in result) {
-          $(that).hide();
-          $title_container.find('.title-input').val(result['title_raw']);
-          $(that).next(".image-edit-title-form").addClass('is-active');
-        }
-      }, 'json');
-
-    });
-
-    $(".image-edit-title-form").submit(function() {
-      var data = $(this).serialize();
-      var url = $(this).attr('action');
-      var that = this;
-      $.post(url, data, function (result){
-        if ('title' in result && 'title_raw' in result) {
-          var $title_container = $(that).closest('.image-title');
-          $title_container.find('.image-edit-title').html(result['title']).show();
-          $title_container.find('.title-input').val(result['title_raw']);
-          $title_container.find('.image-edit-title-form').removeClass('is-active');
-        }
-      }, 'json');
-      return false;
+    $(".image-edit-title-form").submit(function () {
+        var data = $(this).serialize();
+        var url = $(this).attr("action");
+        var that = this;
+        $.post(
+            url,
+            data,
+            function (result) {
+                if ("title" in result && "title_raw" in result) {
+                    var $title_container = $(that).closest(".image-title");
+                    $title_container
+                        .find(".image-edit-title")
+                        .html(result["title"])
+                        .show();
+                    $title_container
+                        .find(".title-input")
+                        .val(result["title_raw"]);
+                    $title_container
+                        .find(".image-edit-title-form")
+                        .removeClass("is-active");
+                }
+            },
+            "json",
+        );
+        return false;
     });
 
     // Inline editing of the description.
-    $(".description-edit-form").submit(function() {
-      var data = $(this).serialize();
-      var url = $(this).attr('action');
-      var that = this;
-      $.post(url, data, function (result){
-        if ('description' in result && 'description_raw' in result) {
-          var $description_container = $(that).closest('.description-edit');
-          $description_container.find('textarea').val(result['description_raw']);
-          $description_container.find('.description-edit-form').hide();
-          if (result['description']) {
-            $description_container.find('.the-description').html(result['description']).show();
-            $description_container.find('.the-description').removeClass('the-description-blank');
-          } else {
-            $description_container.find('.the-description').html('click here to edit description').show();
-            $description_container.find('.the-description').addClass('the-description-blank');
-          }
-        }
-      }, 'json');
-      return false;
+    $(".description-edit-form").submit(function () {
+        var data = $(this).serialize();
+        var url = $(this).attr("action");
+        var that = this;
+        $.post(
+            url,
+            data,
+            function (result) {
+                if ("description" in result && "description_raw" in result) {
+                    var $description_container =
+                        $(that).closest(".description-edit");
+                    $description_container
+                        .find("textarea")
+                        .val(result["description_raw"]);
+                    $description_container
+                        .find(".description-edit-form")
+                        .hide();
+                    if (result["description"]) {
+                        $description_container
+                            .find(".the-description")
+                            .html(result["description"])
+                            .show();
+                        $description_container
+                            .find(".the-description")
+                            .removeClass("the-description-blank");
+                    } else {
+                        $description_container
+                            .find(".the-description")
+                            .html("click here to edit description")
+                            .show();
+                        $description_container
+                            .find(".the-description")
+                            .addClass("the-description-blank");
+                    }
+                }
+            },
+            "json",
+        );
+        return false;
     });
 
-    $(".description-edit .the-description").hover(function() {
-      $(this).addClass('the-description-hover');
-    }, function() {
-      $(this).removeClass('the-description-hover');
+    $(".description-edit .the-description").hover(
+        function () {
+            $(this).addClass("the-description-hover");
+        },
+        function () {
+            $(this).removeClass("the-description-hover");
+        },
+    );
+
+    $(".description-edit .the-description").click(function () {
+        var $description_container = $(this).closest(".description-edit");
+        var url = $description_container.find("form").attr("action");
+        var that = this;
+        $.get(
+            url,
+            function (result) {
+                if ("description_raw" in result) {
+                    $(that).hide();
+                    let $textarea = $description_container.find(
+                        ".description-edit-textarea",
+                    );
+                    $textarea.val(result["description_raw"]);
+                    $(that).next(".description-edit-form").show();
+                    screen_reader_focus($textarea[0]);
+                }
+            },
+            "json",
+        );
     });
 
-    $(".description-edit .the-description").click(function() {
-      var $description_container = $(this).closest('.description-edit');
-      var url = $description_container.find('form').attr('action');
-      var that = this;
-      $.get(url, function(result) {
-        if ('description_raw' in result) {
-          $(that).hide();
-          let $textarea = $description_container.find('.description-edit-textarea');
-          $textarea.val(result['description_raw']);
-          $(that).next(".description-edit-form").show();
-          screen_reader_focus($textarea[0]);
-        }
-      }, 'json');
-    });
-
-    $(".description-edit .cancel").click(function() {
-      $(this).closest('.description-edit').find(".the-description").show();
-      $(this).closest(".description-edit-form").hide();
-      return false;
+    $(".description-edit .cancel").click(function () {
+        $(this).closest(".description-edit").find(".the-description").show();
+        $(this).closest(".description-edit-form").hide();
+        return false;
     });
 
     // Inline editing of the alt text.
-    $(".alt-text-edit-form").submit(function() {
-      var data = $(this).serialize();
-      var url = $(this).attr('action');
-      var that = this;
-      $.post(url, data, function (result){
-        if ('alt_text' in result && 'alt_text_raw' in result) {
-          var $alt_text_container = $(that).closest('.alt-text-edit');
-          if (result['alt_text']) {
-            $alt_text_container.removeClass('alt-text--blank');
-            $alt_text_container.find('.the-alt-text').html(result['alt_text']);
-          } else {
-            $alt_text_container.addClass('alt-text--blank');
-            $alt_text_container.find('.the-alt-text').html('add some alt text');
-          }
-          $alt_text_container.removeClass('alt-text--hidden');
-          $alt_text_container.removeClass('alt-text--editing');
-          $alt_text_container.find('textarea').val(result['alt_text_raw']);
-          screen_reader_focus($alt_text_container.find('.the-alt-text')[0]);
+    $(".alt-text-edit-form").submit(function () {
+        var data = $(this).serialize();
+        var url = $(this).attr("action");
+        var that = this;
+        $.post(
+            url,
+            data,
+            function (result) {
+                if ("alt_text" in result && "alt_text_raw" in result) {
+                    var $alt_text_container = $(that).closest(".alt-text-edit");
+                    if (result["alt_text"]) {
+                        $alt_text_container.removeClass("alt-text--blank");
+                        $alt_text_container
+                            .find(".the-alt-text")
+                            .html(result["alt_text"]);
+                    } else {
+                        $alt_text_container.addClass("alt-text--blank");
+                        $alt_text_container
+                            .find(".the-alt-text")
+                            .html("add some alt text");
+                    }
+                    $alt_text_container.removeClass("alt-text--hidden");
+                    $alt_text_container.removeClass("alt-text--editing");
+                    $alt_text_container
+                        .find("textarea")
+                        .val(result["alt_text_raw"]);
+                    screen_reader_focus(
+                        $alt_text_container.find(".the-alt-text")[0],
+                    );
+                }
+            },
+            "json",
+        );
+        return false;
+    });
+
+    $(".alt-text-edit .the-alt-text").hover(
+        function () {
+            $(this).addClass("the-alt-text-hover");
+        },
+        function () {
+            $(this).removeClass("the-alt-text-hover");
+        },
+    );
+
+    $(".alt-text-edit .the-alt-text").click(function () {
+        var $alt_text_container = $(this).closest(".alt-text-edit");
+        var url = $alt_text_container.find("form").attr("action");
+        var that = this;
+        $.get(
+            url,
+            function (result) {
+                if ("alt_text_raw" in result) {
+                    $(that)
+                        .closest(".alt-text-edit")
+                        .addClass("alt-text--editing");
+                    let $textarea = $alt_text_container.find(
+                        ".alt-text-edit-textarea",
+                    );
+                    $textarea.val(result["alt_text_raw"]);
+                    screen_reader_focus($textarea[0]);
+                }
+            },
+            "json",
+        );
+    });
+
+    $(".alt-text-edit .cancel").click(function () {
+        $(this).closest(".alt-text-edit").removeClass("alt-text--hidden");
+        $(this).closest(".alt-text-edit").removeClass("alt-text--editing");
+        return false;
+    });
+
+    $(".alt-text-toggle").click(function () {
+        let $alt = $(this).closest(".alt-text");
+        $alt.toggleClass("alt-text--hidden");
+        if (!$alt.hasClass("alt-text--hidden")) {
+            screen_reader_focus($alt.find(".the-alt-text")[0]);
         }
-      }, 'json');
-      return false;
     });
 
-    $(".alt-text-edit .the-alt-text").hover(function() {
-      $(this).addClass('the-alt-text-hover');
-    }, function() {
-      $(this).removeClass('the-alt-text-hover');
-    });
-
-    $(".alt-text-edit .the-alt-text").click(function() {
-      var $alt_text_container = $(this).closest('.alt-text-edit');
-      var url = $alt_text_container.find('form').attr('action');
-      var that = this;
-      $.get(url, function(result) {
-        if ('alt_text_raw' in result) {
-          $(that).closest('.alt-text-edit').addClass('alt-text--editing');
-          let $textarea = $alt_text_container.find('.alt-text-edit-textarea');
-          $textarea.val(result['alt_text_raw']);
-          screen_reader_focus($textarea[0]);
-        }
-      }, 'json');
-    });
-
-    $(".alt-text-edit .cancel").click(function() {
-      $(this).closest('.alt-text-edit').removeClass('alt-text--hidden');
-      $(this).closest('.alt-text-edit').removeClass('alt-text--editing');
-      return false;
-    });
-
-    $(".alt-text-toggle").click(function() {
-      let $alt = $(this).closest('.alt-text');
-      $alt.toggleClass('alt-text--hidden');
-      if (!$alt.hasClass('alt-text--hidden')) {
-        screen_reader_focus($alt.find('.the-alt-text')[0]);
-      }
-    });
-
-    $(".delete-from-shakes-form").click(function() {
-      return confirm('Are you sure you want to remove it?');
+    $(".delete-from-shakes-form").click(function () {
+        return confirm("Are you sure you want to remove it?");
     });
 
     /* Like / Unlike button */
-    $(".like-button, .unlike-button").click(function() {
-      var to_text =  function(num, base) {
-        return (num == 1) ? num + ' ' + "<span>" + base + "</span>" : num + ' ' + "<span>" + base + 's' + "</span>";
-      }
+    $(".like-button, .unlike-button").click(function () {
+        var to_text = function (num, base) {
+            return num == 1
+                ? num + " " + "<span>" + base + "</span>"
+                : num + " " + "<span>" + base + "s" + "</span>";
+        };
 
-      var $form = $(this).parents('form');
-      var $buttons = $form.children('button');
-      var url = $form.attr('action');
-      var data = $form.serialize() + '&json=1';
+        var $form = $(this).parents("form");
+        var $buttons = $form.children("button");
+        var url = $form.attr("action");
+        var data = $form.serialize() + "&json=1";
 
-      $.post(url, data, function(response) {
-        if (response['error']) {
-          return false;
-        } else {
-          var count = response['count'];
-          var share_key = response['share_key'];
-          var count_string = to_text(count, "Like");
-          $("#like-count-amount-" + share_key).html(count_string);
-          if (response['like'] === true) {
-            $form.attr('action', '/p/' + share_key + '/unlike');
-          } else {
-            $form.attr('action', '/p/' + share_key + '/like');
-          }
-          $buttons.toggleClass('is-active');
-          SidebarStatsView.refresh_likes();
-          StreamStatsViewRegistry.refresh_likes(share_key);
-        }
-      }, "json");
-      return false;
+        $.post(
+            url,
+            data,
+            function (response) {
+                if (response["error"]) {
+                    return false;
+                } else {
+                    var count = response["count"];
+                    var share_key = response["share_key"];
+                    var count_string = to_text(count, "Like");
+                    $("#like-count-amount-" + share_key).html(count_string);
+                    if (response["like"] === true) {
+                        $form.attr("action", "/p/" + share_key + "/unlike");
+                    } else {
+                        $form.attr("action", "/p/" + share_key + "/like");
+                    }
+                    $buttons.toggleClass("is-active");
+                    SidebarStatsView.refresh_likes();
+                    StreamStatsViewRegistry.refresh_likes(share_key);
+                }
+            },
+            "json",
+        );
+        return false;
     });
 
-    var ImageStats = function() {
-      return {
-        save_count: 0,
-        like_count: 0
-      }
-    }
-
-    var SidebarStatsView = function(scope) {
-      // if we aren't on a permalink page, just expose a dummy public API
-      if ($(scope).length == 0) {
+    var ImageStats = function () {
         return {
-          init: function() {},
-          refresh_likes: function() {},
-          refresh_saves: function() {}
+            save_count: 0,
+            like_count: 0,
         };
-      }
+    };
 
-      var image_stats = new ImageStats();
-      $save_count = $('.save-count', scope);
-      $like_count = $('.like-count', scope);
-      image_stats.save_count = parseInt($save_count.html(), 10);
-      image_stats.like_count = parseInt($like_count.html(), 10);
-
-      var $save_button = $(".sidebar-stats-saves", scope);
-      var $like_button = $(".sidebar-stats-hearts", scope);
-      var $content = $(".sidebar-stats-content", scope);
-
-      var saves_expanded = false;
-      var likes_expanded = false;
-
-      return {
-        init: function() {
-          if (image_stats.save_count > 0) {
-            this.bind_saves();
-          } else {
-            this.unbind_saves();
-          }
-          if (image_stats.like_count > 0) {
-            this.bind_likes();
-            this.toggle_likes();
-          } else {
-            this.unbind_likes();
-          }
-        },
-
-        refresh_likes: function() {
-          $like_count = $('.like-count', scope);
-          image_stats.like_count = parseInt($like_count.html(), 10);
-          if (likes_expanded) {
-            this.get_likes();
-          }
-          if (image_stats.like_count > 0) {
-            this.bind_likes();
-          } else {
-            likes_expanded = false;
-            this.unbind_likes();
-          }
-        },
-
-        refresh_saves: function() {
-          $save_count = $('.save-count', scope);
-          image_stats.save_count = parseInt($save_count.html(), 10);
-          if (saves_expanded) {
-            this.get_saves();
-          }
-          if (image_stats.save_count > 0) {
-            this.bind_saves();
-          } else {
-            saves_expanded = false;
-            this.unbind_saves();
-          }
-        },
-
-        bind_saves: function() {
-          $save_button.unbind('click');
-          $save_button.addClass('enable-cursor');
-          $save_button.click(function() {
-            SidebarStatsView.toggle_saves();
-          });
-        },
-
-        unbind_saves: function() {
-          $save_button.removeClass('enable-cursor');
-          $save_button.unbind('click');
-          this.collapse();
-        },
-
-        bind_likes: function() {
-          $like_button.unbind('click');
-          $like_button.addClass('enable-cursor');
-          $like_button.click(function() {
-            SidebarStatsView.toggle_likes();
-          });
-
-        },
-
-        unbind_likes: function() {
-          $like_button.removeClass('enable-cursor');
-          $like_button.unbind('click');
-          this.collapse();
-        },
-
-        toggle_saves: function() {
-          likes_expanded = false;
-          saves_expanded = !saves_expanded;
-          if (saves_expanded) {
-            $like_button.removeClass('selected');
-            $content.addClass('loading').show();
-            $save_button.addClass('selected');
-            this.get_saves();
-          } else {
-            this.collapse();
-          }
-        },
-
-        get_saves: function() {
-          $.get(document.location.pathname + '/saves', function(response) {
-            if (response['result']) {
-              SidebarStatsView.process_save(response);
-            }
-          }, 'json');
-        },
-
-        toggle_likes: function() {
-          saves_expanded = false;
-          likes_expanded = !likes_expanded;
-          if (likes_expanded) {
-            $save_button.removeClass('selected');
-            $content.addClass('loading').show();
-            $like_button.addClass('selected');
-            this.get_likes();
-          } else {
-            this.collapse();
-          }
-        },
-
-        get_likes:function() {
-          $.get(document.location.pathname + '/likes', function(response) {
-            if (response['result']) {
-              SidebarStatsView.process_like(response);
-            }
-          }, 'json');
-        },
-
-        process_save: function(response) {
-          if (response['count'] == 0) {
-            this.disable_saves();
-          } else {
-            $save_count.html(this.to_text(response['count'], 'Save'));
-            this.render_content(response);
-          }
-        },
-
-        process_like: function(response) {
-          if (response['count'] == 0) {
-            this.unbind_likes();
-          } else {
-            $like_count.html(this.to_text(response['count'], 'Like'));
-            this.render_content(response);
-          }
-        },
-
-        to_text: function(num, base) {
-          return (num == 1) ? num + ' ' + "<span>" + base + "</span>" : num + ' ' + "<span>" + base + 's' + "</span>";
-        },
-
-        collapse: function(repsponse) {
-          $like_button.removeClass('selected');
-          $save_button.removeClass('selected');
-          $content.hide();
-        },
-
-        render_content: function(response) {
-          var html = "";
-          for (var i = 0, len = response['result'].length;  i < len; i++ ) {
-            html += '<div class="user-action">';
-            html += '<a class="icon" href="/user/' + response['result'][i]['user_name'] + '">';
-            html += '<img class="avatar--img" src="' + response['result'][i]['user_profile_image_url'] + '" height="20" width="20" alt=""></a>';
-            html += '<a href="/user/'+ response['result'][i]['user_name'] + '" class="name">' + response['result'][i]['user_name'] + '</a>';
-            html += '<span class="date">' + response['result'][i]['posted_at_friendly'] + '</span>';
-            html += '</div>';
-          }
-          $content.removeClass('loading').html(html);
+    var SidebarStatsView = (function (scope) {
+        // if we aren't on a permalink page, just expose a dummy public API
+        if ($(scope).length == 0) {
+            return {
+                init: function () {},
+                refresh_likes: function () {},
+                refresh_saves: function () {},
+            };
         }
 
-      }
-    }("#sidebar-stats");
+        var image_stats = new ImageStats();
+        $save_count = $(".save-count", scope);
+        $like_count = $(".like-count", scope);
+        image_stats.save_count = parseInt($save_count.html(), 10);
+        image_stats.like_count = parseInt($like_count.html(), 10);
+
+        var $save_button = $(".sidebar-stats-saves", scope);
+        var $like_button = $(".sidebar-stats-hearts", scope);
+        var $content = $(".sidebar-stats-content", scope);
+
+        var saves_expanded = false;
+        var likes_expanded = false;
+
+        return {
+            init: function () {
+                if (image_stats.save_count > 0) {
+                    this.bind_saves();
+                } else {
+                    this.unbind_saves();
+                }
+                if (image_stats.like_count > 0) {
+                    this.bind_likes();
+                    this.toggle_likes();
+                } else {
+                    this.unbind_likes();
+                }
+            },
+
+            refresh_likes: function () {
+                $like_count = $(".like-count", scope);
+                image_stats.like_count = parseInt($like_count.html(), 10);
+                if (likes_expanded) {
+                    this.get_likes();
+                }
+                if (image_stats.like_count > 0) {
+                    this.bind_likes();
+                } else {
+                    likes_expanded = false;
+                    this.unbind_likes();
+                }
+            },
+
+            refresh_saves: function () {
+                $save_count = $(".save-count", scope);
+                image_stats.save_count = parseInt($save_count.html(), 10);
+                if (saves_expanded) {
+                    this.get_saves();
+                }
+                if (image_stats.save_count > 0) {
+                    this.bind_saves();
+                } else {
+                    saves_expanded = false;
+                    this.unbind_saves();
+                }
+            },
+
+            bind_saves: function () {
+                $save_button.unbind("click");
+                $save_button.addClass("enable-cursor");
+                $save_button.click(function () {
+                    SidebarStatsView.toggle_saves();
+                });
+            },
+
+            unbind_saves: function () {
+                $save_button.removeClass("enable-cursor");
+                $save_button.unbind("click");
+                this.collapse();
+            },
+
+            bind_likes: function () {
+                $like_button.unbind("click");
+                $like_button.addClass("enable-cursor");
+                $like_button.click(function () {
+                    SidebarStatsView.toggle_likes();
+                });
+            },
+
+            unbind_likes: function () {
+                $like_button.removeClass("enable-cursor");
+                $like_button.unbind("click");
+                this.collapse();
+            },
+
+            toggle_saves: function () {
+                likes_expanded = false;
+                saves_expanded = !saves_expanded;
+                if (saves_expanded) {
+                    $like_button.removeClass("selected");
+                    $content.addClass("loading").show();
+                    $save_button.addClass("selected");
+                    this.get_saves();
+                } else {
+                    this.collapse();
+                }
+            },
+
+            get_saves: function () {
+                $.get(
+                    document.location.pathname + "/saves",
+                    function (response) {
+                        if (response["result"]) {
+                            SidebarStatsView.process_save(response);
+                        }
+                    },
+                    "json",
+                );
+            },
+
+            toggle_likes: function () {
+                saves_expanded = false;
+                likes_expanded = !likes_expanded;
+                if (likes_expanded) {
+                    $save_button.removeClass("selected");
+                    $content.addClass("loading").show();
+                    $like_button.addClass("selected");
+                    this.get_likes();
+                } else {
+                    this.collapse();
+                }
+            },
+
+            get_likes: function () {
+                $.get(
+                    document.location.pathname + "/likes",
+                    function (response) {
+                        if (response["result"]) {
+                            SidebarStatsView.process_like(response);
+                        }
+                    },
+                    "json",
+                );
+            },
+
+            process_save: function (response) {
+                if (response["count"] == 0) {
+                    this.disable_saves();
+                } else {
+                    $save_count.html(this.to_text(response["count"], "Save"));
+                    this.render_content(response);
+                }
+            },
+
+            process_like: function (response) {
+                if (response["count"] == 0) {
+                    this.unbind_likes();
+                } else {
+                    $like_count.html(this.to_text(response["count"], "Like"));
+                    this.render_content(response);
+                }
+            },
+
+            to_text: function (num, base) {
+                return num == 1
+                    ? num + " " + "<span>" + base + "</span>"
+                    : num + " " + "<span>" + base + "s" + "</span>";
+            },
+
+            collapse: function (repsponse) {
+                $like_button.removeClass("selected");
+                $save_button.removeClass("selected");
+                $content.hide();
+            },
+
+            render_content: function (response) {
+                var html = "";
+                for (var i = 0, len = response["result"].length; i < len; i++) {
+                    html += '<div class="user-action">';
+                    html +=
+                        '<a class="icon" href="/user/' +
+                        response["result"][i]["user_name"] +
+                        '">';
+                    html +=
+                        '<img class="avatar--img" src="' +
+                        response["result"][i]["user_profile_image_url"] +
+                        '" height="20" width="20" alt=""></a>';
+                    html +=
+                        '<a href="/user/' +
+                        response["result"][i]["user_name"] +
+                        '" class="name">' +
+                        response["result"][i]["user_name"] +
+                        "</a>";
+                    html +=
+                        '<span class="date">' +
+                        response["result"][i]["posted_at_friendly"] +
+                        "</span>";
+                    html += "</div>";
+                }
+                $content.removeClass("loading").html(html);
+            },
+        };
+    })("#sidebar-stats");
     SidebarStatsView.init();
 
-
-    var StreamStatsView = function($image_content_footer) {
-      this.$image_content_footer = $image_content_footer;
-      this.share_key = this.$image_content_footer.attr('id').replace('image-content-footer-', '');
-      this.can_submit_comments = true;
-      this.init_dom();
-      this.init_events();
+    var StreamStatsView = function ($image_content_footer) {
+        this.$image_content_footer = $image_content_footer;
+        this.share_key = this.$image_content_footer
+            .attr("id")
+            .replace("image-content-footer-", "");
+        this.can_submit_comments = true;
+        this.init_dom();
+        this.init_events();
     };
 
     $.extend(StreamStatsView.prototype, {
-      init_dom: function() {
-        this.$likes_button = this.$image_content_footer.find('.likes');
-        this.$saves_button = this.$image_content_footer.find('.saves');
-        this.$comments_button = this.$image_content_footer.find('.comments');
-        this.$inline_details = this.$image_content_footer.find('.inline-details');
-        this.init_comment_dom();
-      },
+        init_dom: function () {
+            this.$likes_button = this.$image_content_footer.find(".likes");
+            this.$saves_button = this.$image_content_footer.find(".saves");
+            this.$comments_button =
+                this.$image_content_footer.find(".comments");
+            this.$inline_details =
+                this.$image_content_footer.find(".inline-details");
+            this.init_comment_dom();
+        },
 
-      init_comment_dom: function() {
-        this.$post_comment_inline = this.$inline_details.find('.post-comment-inline')
-        this.$comment_form = this.$inline_details.find('.post-comment-form');
-        this.$comment_textarea = this.$inline_details.find('textarea');
-        this.$submit_comment_button = this.$inline_details.find('.submit-comment-button');
-        this.$show_more_comments = this.$inline_details.find('.show-more-comments');
-        this.$comment = this.$inline_details.find('.comment');
-        this.$reply_to = this.$inline_details.find('.reply-to');
-        this.$delete = this.$inline_details.find('.delete');
-      },
+        init_comment_dom: function () {
+            this.$post_comment_inline = this.$inline_details.find(
+                ".post-comment-inline",
+            );
+            this.$comment_form =
+                this.$inline_details.find(".post-comment-form");
+            this.$comment_textarea = this.$inline_details.find("textarea");
+            this.$submit_comment_button = this.$inline_details.find(
+                ".submit-comment-button",
+            );
+            this.$show_more_comments = this.$inline_details.find(
+                ".show-more-comments",
+            );
+            this.$comment = this.$inline_details.find(".comment");
+            this.$reply_to = this.$inline_details.find(".reply-to");
+            this.$delete = this.$inline_details.find(".delete");
+        },
 
-      init_events: function() {
-        this.$likes_button.click($.proxy(this.click_like, this));
-        this.$saves_button.click($.proxy(this.click_saves, this));
-        this.$comments_button.click($.proxy(this.click_comments, this));
-        this.init_comment_events();
-      },
+        init_events: function () {
+            this.$likes_button.click($.proxy(this.click_like, this));
+            this.$saves_button.click($.proxy(this.click_saves, this));
+            this.$comments_button.click($.proxy(this.click_comments, this));
+            this.init_comment_events();
+        },
 
-      init_comment_events: function () {
-        this.$comment_textarea.click($.proxy(this.click_comment_textarea, this));
-        this.$show_more_comments.click($.proxy(this.click_more_comments, this));
-        this.$reply_to.click($.proxy(this.click_reply_to, this));
-        this.$delete.click($.proxy(this.click_delete, this));
-        // Fix for Webkit bug where textarea looses focus incorrectly on mouseup.
-        // http://code.google.com/p/chromium/issues/detail?id=4505
-        this.$comment_textarea.mouseup(function(e) { e.preventDefault(); });
-        this.$comment_form.submit($.proxy(this.submit_comment, this));
-      },
+        init_comment_events: function () {
+            this.$comment_textarea.click(
+                $.proxy(this.click_comment_textarea, this),
+            );
+            this.$show_more_comments.click(
+                $.proxy(this.click_more_comments, this),
+            );
+            this.$reply_to.click($.proxy(this.click_reply_to, this));
+            this.$delete.click($.proxy(this.click_delete, this));
+            // Fix for Webkit bug where textarea looses focus incorrectly on mouseup.
+            // http://code.google.com/p/chromium/issues/detail?id=4505
+            this.$comment_textarea.mouseup(function (e) {
+                e.preventDefault();
+            });
+            this.$comment_form.submit($.proxy(this.submit_comment, this));
+        },
 
-      // Removes selected state from all tabs.
-      clear_tab_selection: function() {
-        this.$likes_button.removeClass('selected');
-        this.$saves_button.removeClass('selected');
-        this.$comments_button.removeClass('selected');
-      },
+        // Removes selected state from all tabs.
+        clear_tab_selection: function () {
+            this.$likes_button.removeClass("selected");
+            this.$saves_button.removeClass("selected");
+            this.$comments_button.removeClass("selected");
+        },
 
-      // Start the "loading" state transition.
-      start_loading: function() {
-        this.$inline_details.addClass('inline-details-loading').html('').show();
-      },
+        // Start the "loading" state transition.
+        start_loading: function () {
+            this.$inline_details
+                .addClass("inline-details-loading")
+                .html("")
+                .show();
+        },
 
-      user_html: function(data) {
-        var html = '';
-        for (var i = 0; i < data.result.length; i++) {
-          html += '<a href="/user/' + data.result[i]['user_name'] + '">' +
-                  '<img class="avatar--img" src="' +
-                  data.result[i]['user_profile_image_url'] + '" height="20" width="20" alt="">' +
-                  '<span class="name">' +
-                  data.result[i]['user_name'] + '</span></a>';
-        }
-        return html;
-      },
+        user_html: function (data) {
+            var html = "";
+            for (var i = 0; i < data.result.length; i++) {
+                html +=
+                    '<a href="/user/' +
+                    data.result[i]["user_name"] +
+                    '">' +
+                    '<img class="avatar--img" src="' +
+                    data.result[i]["user_profile_image_url"] +
+                    '" height="20" width="20" alt="">' +
+                    '<span class="name">' +
+                    data.result[i]["user_name"] +
+                    "</span></a>";
+            }
+            return html;
+        },
 
-      click_like: function() {
-        if (this.$likes_button.hasClass('selected')) {
-          this.clear_tab_selection();
-          this.$inline_details.hide();
-          return false;
-        }
-        this.clear_tab_selection();
-        this.$likes_button.addClass('selected');
-        this.start_loading();
-        this.load_likes();
-        return false;
-      },
+        click_like: function () {
+            if (this.$likes_button.hasClass("selected")) {
+                this.clear_tab_selection();
+                this.$inline_details.hide();
+                return false;
+            }
+            this.clear_tab_selection();
+            this.$likes_button.addClass("selected");
+            this.start_loading();
+            this.load_likes();
+            return false;
+        },
 
-      load_likes: function() {
-        var url = '/p/' + this.share_key + '/likes';
-        $.get(url, $.proxy(this.process_like_response, this), 'json');
-      },
+        load_likes: function () {
+            var url = "/p/" + this.share_key + "/likes";
+            $.get(url, $.proxy(this.process_like_response, this), "json");
+        },
 
-      process_like_response: function(data) {
-        var html = '<div class="user-saves-likes">' + this.user_html(data) + '</div>';
-        this.$inline_details.html(html);
-      },
+        process_like_response: function (data) {
+            var html =
+                '<div class="user-saves-likes">' +
+                this.user_html(data) +
+                "</div>";
+            this.$inline_details.html(html);
+        },
 
-      click_saves: function() {
-        if (this.$saves_button.hasClass('selected')) {
-          this.clear_tab_selection();
-          this.$inline_details.hide();
-          return false;
-        }
+        click_saves: function () {
+            if (this.$saves_button.hasClass("selected")) {
+                this.clear_tab_selection();
+                this.$inline_details.hide();
+                return false;
+            }
 
-        this.clear_tab_selection();
-        this.$saves_button.addClass('selected');
-        this.start_loading();
-        this.load_saves();
-        return false;
-      },
+            this.clear_tab_selection();
+            this.$saves_button.addClass("selected");
+            this.start_loading();
+            this.load_saves();
+            return false;
+        },
 
-      load_saves: function() {
-        var url = '/p/' + this.share_key + '/saves';
-        $.get(url, $.proxy(this.process_like_response, this), 'json');
-      },
+        load_saves: function () {
+            var url = "/p/" + this.share_key + "/saves";
+            $.get(url, $.proxy(this.process_like_response, this), "json");
+        },
 
-      click_comments: function() {
-        if (this.$comments_button.hasClass('selected')) {
-          this.clear_tab_selection();
-          this.$inline_details.hide();
-          return false;
-        }
+        click_comments: function () {
+            if (this.$comments_button.hasClass("selected")) {
+                this.clear_tab_selection();
+                this.$inline_details.hide();
+                return false;
+            }
 
-        this.clear_tab_selection();
-        this.$comments_button.addClass('selected');
-        this.start_loading();
-        var url = '/p/' + this.share_key + '/quick-comments';
-        $.get(url, $.proxy(this.process_comments_response, this), 'json');
-        return false;
-      },
+            this.clear_tab_selection();
+            this.$comments_button.addClass("selected");
+            this.start_loading();
+            var url = "/p/" + this.share_key + "/quick-comments";
+            $.get(url, $.proxy(this.process_comments_response, this), "json");
+            return false;
+        },
 
-      click_more_comments: function() {
-        this.$comment.show();
-        this.$show_more_comments.hide();
-        return false;
-      },
+        click_more_comments: function () {
+            this.$comment.show();
+            this.$show_more_comments.hide();
+            return false;
+        },
 
-      process_comments_response: function(data) {
-        this.can_submit_comments = true;
-        if (data['result'] == 'ok') {
-          this.$comments_button.find('a').html(data['count']);
-          this.$inline_details.html(data['html']);
-          this.init_comment_dom();
-          this.init_comment_events();
-        }
-      },
+        process_comments_response: function (data) {
+            this.can_submit_comments = true;
+            if (data["result"] == "ok") {
+                this.$comments_button.find("a").html(data["count"]);
+                this.$inline_details.html(data["html"]);
+                this.init_comment_dom();
+                this.init_comment_events();
+            }
+        },
 
-      click_reply_to: function(ev) {
-        this.click_comment_textarea();
-        var username = $(ev.target).parents('.comment').find('.username').html();
-        var username_clean = username.replace(/[^a-zA-Z0-9_\-]+/g, '');
-        var current_text = this.$comment_textarea.val();
-        this.$comment_textarea.val(current_text + "@" + username_clean + ' ');
-        setCaret(this.$comment_textarea.get(0));
-        return false;
-      },
+        click_reply_to: function (ev) {
+            this.click_comment_textarea();
+            var username = $(ev.target)
+                .parents(".comment")
+                .find(".username")
+                .html();
+            var username_clean = username.replace(/[^a-zA-Z0-9_\-]+/g, "");
+            var current_text = this.$comment_textarea.val();
+            this.$comment_textarea.val(
+                current_text + "@" + username_clean + " ",
+            );
+            setCaret(this.$comment_textarea.get(0));
+            return false;
+        },
 
-      click_delete: function(ev) {
-        var $delete_form = $("#" + ev.target.id + '-form'),
-                     url = $delete_form.attr('action'),
-                    data = $delete_form.serialize();
-        if (confirm("Are you sure you want to delete this?")) {
-          $.post(url, data, $.proxy(this.process_comments_response, this), 'json');
-        }
-        return false;
-      },
+        click_delete: function (ev) {
+            var $delete_form = $("#" + ev.target.id + "-form"),
+                url = $delete_form.attr("action"),
+                data = $delete_form.serialize();
+            if (confirm("Are you sure you want to delete this?")) {
+                $.post(
+                    url,
+                    data,
+                    $.proxy(this.process_comments_response, this),
+                    "json",
+                );
+            }
+            return false;
+        },
 
-      submit_comment: function() {
-        if (this.can_submit_comments === false) {
-          return false;
-        }
-        this.can_submit_comments = false;
-        var url = this.$comment_form.attr('action');
-        var data = this.$comment_form.serialize();
-        $.post(url, data, $.proxy(this.process_comments_response, this), 'json');
-        return false;
-      },
+        submit_comment: function () {
+            if (this.can_submit_comments === false) {
+                return false;
+            }
+            this.can_submit_comments = false;
+            var url = this.$comment_form.attr("action");
+            var data = this.$comment_form.serialize();
+            $.post(
+                url,
+                data,
+                $.proxy(this.process_comments_response, this),
+                "json",
+            );
+            return false;
+        },
 
-      click_comment_textarea: function(e) {
-        this.$post_comment_inline.addClass('post-comment-inline-expanded');
-        if (this.$comment_textarea.val().indexOf('Write a comment') === 0) {
-          this.$comment_textarea.val('');
-        }
-        this.click_more_comments();
-        this.$comment_textarea.css('min-height', '60px');
-      },
+        click_comment_textarea: function (e) {
+            this.$post_comment_inline.addClass("post-comment-inline-expanded");
+            if (this.$comment_textarea.val().indexOf("Write a comment") === 0) {
+                this.$comment_textarea.val("");
+            }
+            this.click_more_comments();
+            this.$comment_textarea.css("min-height", "60px");
+        },
 
-      refresh_likes: function() {
-        if (this.$likes_button.hasClass('selected')) {
-          this.load_likes();
-        }
-      },
+        refresh_likes: function () {
+            if (this.$likes_button.hasClass("selected")) {
+                this.load_likes();
+            }
+        },
 
-      refresh_saves: function() {
-        if (this.$saves_button.hasClass('selected')) {
-          this.load_saves();
-        }
-      }
+        refresh_saves: function () {
+            if (this.$saves_button.hasClass("selected")) {
+                this.load_saves();
+            }
+        },
     });
 
     var StreamStatsViewRegistry = {
-      files_on_page: {},
-      register: function(view) {
-        this.files_on_page[view.share_key] = view;
-      },
-      refresh_likes: function(share_key) {
-        view = this.get_view(share_key);
-        if (view !== undefined) {
-          view.refresh_likes();
-        }
-      },
-      refresh_saves: function(share_key) {
-        view = this.get_view(share_key);
-        if (view !== undefined) {
-          view.refresh_saves();
-        }
-      },
-      get_view: function(share_key) {
-        return this.files_on_page[share_key];
-      }
-    }
+        files_on_page: {},
+        register: function (view) {
+            this.files_on_page[view.share_key] = view;
+        },
+        refresh_likes: function (share_key) {
+            view = this.get_view(share_key);
+            if (view !== undefined) {
+                view.refresh_likes();
+            }
+        },
+        refresh_saves: function (share_key) {
+            view = this.get_view(share_key);
+            if (view !== undefined) {
+                view.refresh_saves();
+            }
+        },
+        get_view: function (share_key) {
+            return this.files_on_page[share_key];
+        },
+    };
 
     function apply_hover_for_video(sel) {
-      sel.hover(function () {
-        if (this.hasAttribute("controls")) {
-          this.removeAttribute("controls")
-        } else {
-          this.setAttribute("controls", "controls")
-        }
-      });
+        sel.hover(function () {
+            if (this.hasAttribute("controls")) {
+                this.removeAttribute("controls");
+            } else {
+                this.setAttribute("controls", "controls");
+            }
+        });
     }
 
-    var NSFWCover = function($root) {
-      this.$root = $root;
-      this.init();
-    }
+    var NSFWCover = function ($root) {
+        this.$root = $root;
+        this.init();
+    };
 
     $.extend(NSFWCover.prototype, {
-      init: function() {
-        this.$root.delegate('a', 'click', $.proxy(this.click_show_image, this));
-      },
+        init: function () {
+            this.$root.delegate(
+                "a",
+                "click",
+                $.proxy(this.click_show_image, this),
+            );
+        },
 
-      click_show_image: function(ev) {
-        var location = document.location,
-            host = location.host,
-            protocol = location.protocol,
-            base_path = location.protocol + "//" + location.host,
-            file_path = $(ev.target).attr('href');
-        $.get(base_path + "/services/oembed?include_embed=1&url=" + escape(base_path + file_path), $.proxy(this.load_image, this), 'json');
-        return false;
-      },
+        click_show_image: function (ev) {
+            var location = document.location,
+                host = location.host,
+                protocol = location.protocol,
+                base_path = location.protocol + "//" + location.host,
+                file_path = $(ev.target).attr("href");
+            $.get(
+                base_path +
+                    "/services/oembed?include_embed=1&url=" +
+                    escape(base_path + file_path),
+                $.proxy(this.load_image, this),
+                "json",
+            );
+            return false;
+        },
 
-      load_image: function(response) {
-        var parent = this.$root.parent(),
-            parent_height = parent.height();
+        load_image: function (response) {
+            var parent = this.$root.parent(),
+                parent_height = parent.height();
 
-        if (response['type'] === 'photo') {
-          parent.css('min-height', parent_height + 'px').html('<img class="unsized" src="' + response['url'] + '">');
-        } else if (response['embed_html']) {
-          parent.css('min-height', parent_height + 'px').html('<div class="data-wrapper">' + response['embed_html'] + '</div>');
-        } else if (response['type'] === 'video') {
-          var content = parent.css('min-height', parent_height + 'px').html(response['html'].replace(/<source /g, '<source onerror="fallbackImage(this)" '));
-          apply_hover_for_video(content.find('video.autoplay'));
-        }
-      }
+            if (response["type"] === "photo") {
+                parent
+                    .css("min-height", parent_height + "px")
+                    .html(
+                        '<img class="unsized" src="' + response["url"] + '">',
+                    );
+            } else if (response["embed_html"]) {
+                parent
+                    .css("min-height", parent_height + "px")
+                    .html(
+                        '<div class="data-wrapper">' +
+                            response["embed_html"] +
+                            "</div>",
+                    );
+            } else if (response["type"] === "video") {
+                var content = parent
+                    .css("min-height", parent_height + "px")
+                    .html(
+                        response["html"].replace(
+                            /<source /g,
+                            '<source onerror="fallbackImage(this)" ',
+                        ),
+                    );
+                apply_hover_for_video(content.find("video.autoplay"));
+            }
+        },
     });
 
-    $(".image-content").each(function() {
-      var $image_content = $(this),
-          $image_footer = $image_content.find(".image-content-footer"),
-          $nsfw_cover = $image_content.find(".nsfw-cover");
-      var stream_stats_view = new StreamStatsView($image_footer);
-      StreamStatsViewRegistry.register(stream_stats_view);
-      var nsfw_cover = new NSFWCover($nsfw_cover);
+    $(".image-content").each(function () {
+        var $image_content = $(this),
+            $image_footer = $image_content.find(".image-content-footer"),
+            $nsfw_cover = $image_content.find(".nsfw-cover");
+        var stream_stats_view = new StreamStatsView($image_footer);
+        StreamStatsViewRegistry.register(stream_stats_view);
+        var nsfw_cover = new NSFWCover($nsfw_cover);
     });
 
-    apply_hover_for_video($('.image-content video.autoplay'));
+    apply_hover_for_video($(".image-content video.autoplay"));
 
     /* Open / close notification boxes */
-    $(".notification-block-hd").live('click', function() {
-      $(this).next().toggle();
+    $(".notification-block-hd").live("click", function () {
+        $(this).next().toggle();
     });
 
     /* User follow module */
-    $('.user-follow .submit-form').live('click', function() {
-      var $container = $(this).parents('.user-follow');
-      var $form = $container.find('form');
-      var url = $form.attr('action');
-      var data = $form.serialize() + '&json=1';
-      var that = this;
-      $.post(url, data, function(response) {
-        if (response['error']) {
-          return false;
-        } else {
-          if (response['subscription_status'] == true) {
-            $form.attr('action', url.replace('subscribe', 'unsubscribe'));
-            $(that).text('- Unfollow').addClass('btn-warning').removeClass('btn-secondary');
-          } else {
-            $form.attr('action', url.replace('unsubscribe', 'subscribe'));
-            $(that).text('+ Follow').addClass('btn-secondary').removeClass('btn-warning');
-          }
-        }
-
-      }, 'json');
-      return false;
+    $(".user-follow .submit-form").live("click", function () {
+        var $container = $(this).parents(".user-follow");
+        var $form = $container.find("form");
+        var url = $form.attr("action");
+        var data = $form.serialize() + "&json=1";
+        var that = this;
+        $.post(
+            url,
+            data,
+            function (response) {
+                if (response["error"]) {
+                    return false;
+                } else {
+                    if (response["subscription_status"] == true) {
+                        $form.attr(
+                            "action",
+                            url.replace("subscribe", "unsubscribe"),
+                        );
+                        $(that)
+                            .text("- Unfollow")
+                            .addClass("btn-warning")
+                            .removeClass("btn-secondary");
+                    } else {
+                        $form.attr(
+                            "action",
+                            url.replace("unsubscribe", "subscribe"),
+                        );
+                        $(that)
+                            .text("+ Follow")
+                            .addClass("btn-secondary")
+                            .removeClass("btn-warning");
+                    }
+                }
+            },
+            "json",
+        );
+        return false;
     });
 
-    $('.notification-close').live('click', function() {
-      $notification = $(this).parent('.notification');
-      var $notification_block = $(this).parents('.notification-block');
-      var $notification_block_hd = $notification_block.find('.notification-block-hd');
-      var id = $(this).attr('id').replace(/[^\d]+/, '');
-      $.post('/account/clear-notification' + '?type=single&id=' + id, {}, function(response) {
-        $notification.remove();
-        var html = $notification_block_hd.html()
-        var count = html.replace(/[^\d]+/, '');
-        var new_count = parseInt(count, 10) - 1;
-        if (new_count == 0) {
-          $notification_block_hd.html('You have 0 new followers')
-          $notification_block.find('.clear-all').remove();
-        } else {
-          $notification_block_hd.html(html.replace(/[\d]+/, new_count))
-        }
-      }, 'json');
-      return false;
+    $(".notification-close").live("click", function () {
+        $notification = $(this).parent(".notification");
+        var $notification_block = $(this).parents(".notification-block");
+        var $notification_block_hd = $notification_block.find(
+            ".notification-block-hd",
+        );
+        var id = $(this)
+            .attr("id")
+            .replace(/[^\d]+/, "");
+        $.post(
+            "/account/clear-notification" + "?type=single&id=" + id,
+            {},
+            function (response) {
+                $notification.remove();
+                var html = $notification_block_hd.html();
+                var count = html.replace(/[^\d]+/, "");
+                var new_count = parseInt(count, 10) - 1;
+                if (new_count == 0) {
+                    $notification_block_hd.html("You have 0 new followers");
+                    $notification_block.find(".clear-all").remove();
+                } else {
+                    $notification_block_hd.html(
+                        html.replace(/[\d]+/, new_count),
+                    );
+                }
+            },
+            "json",
+        );
+        return false;
     });
 
-    $('.notification-block .clear-all a').live('click', function() {
-      var url = $(this).attr('href');
-      var $notification_block = $(this).parents('.notification-block');
-      $.post(url, {}, function(response) {
-        if (response['error']) {
-          return false;
-        } else {
-          $notification_block.find('.notification-block-hd').html(response['response']);
-          $notification_block.find('.notification-block-bd').html('').toggle();
-        }
-      }, 'json');
+    $(".notification-block .clear-all a").live("click", function () {
+        var url = $(this).attr("href");
+        var $notification_block = $(this).parents(".notification-block");
+        $.post(
+            url,
+            {},
+            function (response) {
+                if (response["error"]) {
+                    return false;
+                } else {
+                    $notification_block
+                        .find(".notification-block-hd")
+                        .html(response["response"]);
+                    $notification_block
+                        .find(".notification-block-bd")
+                        .html("")
+                        .toggle();
+                }
+            },
+            "json",
+        );
 
-      return false;
+        return false;
     });
-
 
     /* Notification block: invitations: */
-    $("#notifcation-block-invitations form").live('submit', function() {
-      var data = $(this).serialize();
-      var url  = $(this).attr('action');
+    $("#notifcation-block-invitations form").live("submit", function () {
+        var data = $(this).serialize();
+        var url = $(this).attr("action");
 
-      var that = this;
-      $.post(url, data, function(response) {
+        var that = this;
+        $.post(
+            url,
+            data,
+            function (response) {
+                if (response["error"]) {
+                    $(that)
+                        .find(".main-message")
+                        .html("<p>" + response["error"] + "</p>");
+                } else {
+                    if (response["count"] == 0) {
+                        $(that).find("input").hide();
+                        $("#invitation-count-text").html(
+                            response["count"] + " invitations",
+                        );
+                        $(that).find(".main-message").html("<p>Thanks!</p>");
+                    } else {
+                        var invitation_text =
+                            response["count"] == 1
+                                ? "invitation"
+                                : "invitations";
+                        $("#invitation-count-text").html(
+                            response["count"] + " " + invitation_text,
+                        );
+                        $(that).find(".main-message").html(response["message"]);
+                        $("#email_address").val("");
+                    }
+                }
+            },
+            "json",
+        );
 
-        if (response['error']) {
-          $(that).find(".main-message").html('<p>' + response['error'] + '</p>');
-        } else {
-          if (response['count'] == 0) {
-            $(that).find("input").hide();
-            $("#invitation-count-text").html(response['count'] + " invitations");
-            $(that).find(".main-message").html('<p>Thanks!</p>');
-          } else {
-            var invitation_text = response['count'] == 1 ? 'invitation' : 'invitations';
-            $("#invitation-count-text").html(response['count'] + " " + invitation_text);
-            $(that).find(".main-message").html(response['message']);
-            $("#email_address").val('');
-          }
-        }
-      }, 'json');
-
-      return false;
+        return false;
     });
 
     /* Notification block: shake invitations: */
-    $("#notifcation-block-shakeinvitation form").live('submit', function() {
-      var data = $(this).serialize();
-      var url  = $(this).attr('action');
-      var $block = $(this).parents('.notification');
-      var $header = $("#notifcation-block-shakeinvitation .notification-block-hd");
+    $("#notifcation-block-shakeinvitation form").live("submit", function () {
+        var data = $(this).serialize();
+        var url = $(this).attr("action");
+        var $block = $(this).parents(".notification");
+        var $header = $(
+            "#notifcation-block-shakeinvitation .notification-block-hd",
+        );
 
-      var that = this;
-      $.post(url, data, function(response) {
-        if (!response['error']) {
-          $block.remove();
-          // we update the header differently when presenting only one
-          // invitation on the shake page itself.
-          if ($header.hasClass('invitation-single')) {
-            $header.html('Got it.');
-          } else {
-            var invitation_text = response['count'] == 1 ? 'invitation' : 'invitations';
-            $header.html(response['count'] + ' new shake ' + invitation_text);
-          }
-        }
-      }, 'json');
+        var that = this;
+        $.post(
+            url,
+            data,
+            function (response) {
+                if (!response["error"]) {
+                    $block.remove();
+                    // we update the header differently when presenting only one
+                    // invitation on the shake page itself.
+                    if ($header.hasClass("invitation-single")) {
+                        $header.html("Got it.");
+                    } else {
+                        var invitation_text =
+                            response["count"] == 1
+                                ? "invitation"
+                                : "invitations";
+                        $header.html(
+                            response["count"] + " new shake " + invitation_text,
+                        );
+                    }
+                }
+            },
+            "json",
+        );
 
-      return false;
+        return false;
     });
 
-    var NotificationInvitationContainer = function($root) {
-      this.$root = $root;
-      this.init();
+    var NotificationInvitationContainer = function ($root) {
+        this.$root = $root;
+        this.init();
     };
 
     $.extend(NotificationInvitationContainer.prototype, {
-      init: function() {
-        this.$hd = this.$root.find('.notification-block-hd');
-        this.$bd = this.$root.find('.notification-block-bd');
-        this.on_shake_page = this.$hd.hasClass('on-shake-page');
-        var that = this;
-        this.$root.find('.notification').each(function() {
-          var new_invitation_request = new NotificationInvitationRequest($(this), that);
-        });
-      },
+        init: function () {
+            this.$hd = this.$root.find(".notification-block-hd");
+            this.$bd = this.$root.find(".notification-block-bd");
+            this.on_shake_page = this.$hd.hasClass("on-shake-page");
+            var that = this;
+            this.$root.find(".notification").each(function () {
+                var new_invitation_request = new NotificationInvitationRequest(
+                    $(this),
+                    that,
+                );
+            });
+        },
 
-      update_count: function(count) {
-        if (!this.on_shake_page) {
-          var request_text = count == 1 ? " request" : " requests";
-          var html = count + request_text + " to join a shake";
-          this.$hd.html(html);
-        } else {
-          this.$hd.html("Got it!");
-        }
-      }
+        update_count: function (count) {
+            if (!this.on_shake_page) {
+                var request_text = count == 1 ? " request" : " requests";
+                var html = count + request_text + " to join a shake";
+                this.$hd.html(html);
+            } else {
+                this.$hd.html("Got it!");
+            }
+        },
     });
 
-    var NotificationInvitationRequest = function($root, container) {
-      this.$root = $root;
-      this.container = container;
-      this.init_dom();
-      this.init_events();
+    var NotificationInvitationRequest = function ($root, container) {
+        this.$root = $root;
+        this.container = container;
+        this.init_dom();
+        this.init_events();
     };
 
     $.extend(NotificationInvitationRequest.prototype, {
-      init_dom: function() {
-        this.$form = this.$root.find('form');
-        this.$form_approve_invitation = this.$root.find('.approve-invitation');
-        this.$form_decline_invitation = this.$root.find('.decline-invitation');
-      },
+        init_dom: function () {
+            this.$form = this.$root.find("form");
+            this.$form_approve_invitation = this.$root.find(
+                ".approve-invitation",
+            );
+            this.$form_decline_invitation = this.$root.find(
+                ".decline-invitation",
+            );
+        },
 
-      init_events: function() {
-        this.$root.delegate('.approve-invitation', 'submit', $.proxy(this.submit_approve_invitation, this));
-        this.$root.delegate('.decline-invitation', 'submit', $.proxy(this.submit_decline_invitation, this));
-      },
+        init_events: function () {
+            this.$root.delegate(
+                ".approve-invitation",
+                "submit",
+                $.proxy(this.submit_approve_invitation, this),
+            );
+            this.$root.delegate(
+                ".decline-invitation",
+                "submit",
+                $.proxy(this.submit_decline_invitation, this),
+            );
+        },
 
-      submit_approve_invitation: function(ev) {
-        ev.preventDefault();
-        this.submit_form(this.$form_approve_invitation);
-      },
+        submit_approve_invitation: function (ev) {
+            ev.preventDefault();
+            this.submit_form(this.$form_approve_invitation);
+        },
 
-      submit_decline_invitation: function(ev) {
-        ev.preventDefault();
-        this.submit_form(this.$form_decline_invitation);
-      },
+        submit_decline_invitation: function (ev) {
+            ev.preventDefault();
+            this.submit_form(this.$form_decline_invitation);
+        },
 
-      submit_form: function($form) {
-        var url = $form.attr('action');
-        var data = $form.serialize();
-        $.post(url, data, $.proxy(this.clear_notification, this), 'json');
-      },
+        submit_form: function ($form) {
+            var url = $form.attr("action");
+            var data = $form.serialize();
+            $.post(url, data, $.proxy(this.clear_notification, this), "json");
+        },
 
-      clear_notification: function(response) {
-        if (response['status'] == 'ok') {
-          this.$root.remove();
-          this.container.update_count(response['count']);
-        }
-      }
-
+        clear_notification: function (response) {
+            if (response["status"] == "ok") {
+                this.$root.remove();
+                this.container.update_count(response["count"]);
+            }
+        },
     });
 
-    var init_notification_invitation_request = function() {
-      $notification_invitation_request = $("#notification-block-invitation-request");
-      if ($notification_invitation_request.length > 0) {
-        var invitation_requests = new NotificationInvitationContainer($notification_invitation_request);
-      }
-    }
+    var init_notification_invitation_request = function () {
+        $notification_invitation_request = $(
+            "#notification-block-invitation-request",
+        );
+        if ($notification_invitation_request.length > 0) {
+            var invitation_requests = new NotificationInvitationContainer(
+                $notification_invitation_request,
+            );
+        }
+    };
     init_notification_invitation_request();
 
     // Expand all notifications.
-    $("#notification-block-aggregate").click(function() {
-      $(this).find(".notification-block-hd").html("Loading...");
-      $.get("/account/quick-notifications", function(response) {
-        $("#notification-block-aggregate").hide().after(response);
-        init_notification_invitation_request();
-      });
+    $("#notification-block-aggregate").click(function () {
+        $(this).find(".notification-block-hd").html("Loading...");
+        $.get("/account/quick-notifications", function (response) {
+            $("#notification-block-aggregate").hide().after(response);
+            init_notification_invitation_request();
+        });
     });
 
     /* Action Button in a Fun Form, should submit the form (exception here
        for a button with a g-recaptcha class which has a separate event
        handler). */
-    $(".field-submit .btn:not(.g-recaptcha)").click(function() {
-      $(this).closest("form").submit();
-      return false;
-    })
+    $(".field-submit .btn:not(.g-recaptcha)").click(function () {
+        $(this).closest("form").submit();
+        return false;
+    });
 
     /* Site Nav dropdown */
     $site_nav = $("#site-nav");
     var site_nav_expanded = false;
-    $("#site-nav .site-nav--toggle").click(function(event) {
-      event.stopPropagation();
-      if (site_nav_expanded == false) {
-        site_nav_expanded = true;
-        $site_nav.addClass("is-expanded");
-        $('body').one('click', function() {
-          $site_nav.removeClass("is-expanded");
-          site_nav_expanded = false;
-        });
-      } else {
-        $site_nav.removeClass("is-expanded");
-        $('body').unbind('click');
-        site_nav_expanded = false;
-      }
+    $("#site-nav .site-nav--toggle").click(function (event) {
+        event.stopPropagation();
+        if (site_nav_expanded == false) {
+            site_nav_expanded = true;
+            $site_nav.addClass("is-expanded");
+            $("body").one("click", function () {
+                $site_nav.removeClass("is-expanded");
+                site_nav_expanded = false;
+            });
+        } else {
+            $site_nav.removeClass("is-expanded");
+            $("body").unbind("click");
+            site_nav_expanded = false;
+        }
     });
 
-    $("#site-nav .site-nav--list").click(function(event) {
-      event.stopPropagation();
+    $("#site-nav .site-nav--list").click(function (event) {
+        event.stopPropagation();
     });
 
     /* Choose a shake dropdown */
     $choose_a_shake = $("#choose-a-shake");
     var shake_expanded = false;
-    $("#choose-a-shake .choose-a-shake--toggle").click(function(event) {
-      event.stopPropagation();
-      if (shake_expanded == false) {
-        shake_expanded = true;
-        $choose_a_shake.addClass("is-expanded");
-        $('body').one('click', function() {
-          $choose_a_shake.removeClass("is-expanded");
-          shake_expanded = false;
-        });
-      } else {
-        $choose_a_shake.removeClass("is-expanded");
-        $('body').unbind('click');
-        shake_expanded = false;
-      }
+    $("#choose-a-shake .choose-a-shake--toggle").click(function (event) {
+        event.stopPropagation();
+        if (shake_expanded == false) {
+            shake_expanded = true;
+            $choose_a_shake.addClass("is-expanded");
+            $("body").one("click", function () {
+                $choose_a_shake.removeClass("is-expanded");
+                shake_expanded = false;
+            });
+        } else {
+            $choose_a_shake.removeClass("is-expanded");
+            $("body").unbind("click");
+            shake_expanded = false;
+        }
     });
 
-    $("#choose-a-shake .choose-a-shake--dropdown").click(function(event) {
-      event.stopPropagation();
+    $("#choose-a-shake .choose-a-shake--dropdown").click(function (event) {
+        event.stopPropagation();
     });
 
     /* Conversations - mute this button */
-    $(".mute-this-conversation").click(function() {
-      var $form = $(this).next('.mute-this-conversation-form');
-      var url = $form.attr('action');
-      var data = $form.serialize();
-      var $conversation = $(this).parents('.conversation');
-      $.post(url, data, function() {
-        $conversation.fadeOut('slow');
-      });
-      return false;
+    $(".mute-this-conversation").click(function () {
+        var $form = $(this).next(".mute-this-conversation-form");
+        var url = $form.attr("action");
+        var data = $form.serialize();
+        var $conversation = $(this).parents(".conversation");
+        $.post(url, data, function () {
+            $conversation.fadeOut("slow");
+        });
+        return false;
     });
 
-
     // http://stackoverflow.com/questions/1125292/how-to-move-cursor-to-end-of-contenteditable-entity
-    function setCaret(el)
-    {
+    function setCaret(el) {
         ctrl = el;
         pos = ctrl.value.length;
-        if(ctrl.setSelectionRange)
-        {
+        if (ctrl.setSelectionRange) {
             ctrl.focus();
-            ctrl.setSelectionRange(pos,pos);
-        }
-        else if (ctrl.createTextRange) {
+            ctrl.setSelectionRange(pos, pos);
+        } else if (ctrl.createTextRange) {
             var range = ctrl.createTextRange();
             range.collapse(true);
-            range.moveEnd('character', pos);
-            range.moveStart('character', pos);
+            range.moveEnd("character", pos);
+            range.moveStart("character", pos);
             range.select();
         }
     }
 
-    var PermalinkCommentsView = function($root) {
-      this.$root = $root;
-      this.init();
-      this.init_events();
+    var PermalinkCommentsView = function ($root) {
+        this.$root = $root;
+        this.init();
+        this.init_events();
     };
 
     $.extend(PermalinkCommentsView.prototype, {
-      init: function() {
-        this.$post_comment_body = $("#post-comment-body");
-      },
+        init: function () {
+            this.$post_comment_body = $("#post-comment-body");
+        },
 
-      init_events: function() {
-        this.$root.delegate('.reply-to', 'click', $.proxy(this.click_reply_to, this));
-        this.$root.delegate('.delete', 'click', $.proxy(this.click_delete, this));
-      },
+        init_events: function () {
+            this.$root.delegate(
+                ".reply-to",
+                "click",
+                $.proxy(this.click_reply_to, this),
+            );
+            this.$root.delegate(
+                ".delete",
+                "click",
+                $.proxy(this.click_delete, this),
+            );
+        },
 
-      click_reply_to: function(ev) {
-        var $target = $(ev.target);
-        var $meta = $target.parent();
-        var username = $meta.find('.username').html();
-        var username_clean = username.replace(/[^a-zA-Z0-9_\-]+/g, '');
-        var current_text = this.$post_comment_body.val();
-        this.$post_comment_body.val(current_text + "@" + username_clean + ' ');
-        setCaret(this.$post_comment_body.get(0));
-        window.location.hash = "post-comment";
-        return false;
-      },
+        click_reply_to: function (ev) {
+            var $target = $(ev.target);
+            var $meta = $target.parent();
+            var username = $meta.find(".username").html();
+            var username_clean = username.replace(/[^a-zA-Z0-9_\-]+/g, "");
+            var current_text = this.$post_comment_body.val();
+            this.$post_comment_body.val(
+                current_text + "@" + username_clean + " ",
+            );
+            setCaret(this.$post_comment_body.get(0));
+            window.location.hash = "post-comment";
+            return false;
+        },
 
-      click_delete: function(ev) {
-        var $delete_form = $("#" + ev.target.id + '-form');
-        if (confirm("Are you sure you want to delete this?")) {
-          $delete_form.submit();
-        }
-        return false;
-      }
+        click_delete: function (ev) {
+            var $delete_form = $("#" + ev.target.id + "-form");
+            if (confirm("Are you sure you want to delete this?")) {
+                $delete_form.submit();
+            }
+            return false;
+        },
     });
 
     var $image_comments_permalink = $("#image-comments-permalink");
     if ($image_comments_permalink.length > 0) {
-      var new_comment = new PermalinkCommentsView($image_comments_permalink);
+        var new_comment = new PermalinkCommentsView($image_comments_permalink);
     }
 
-    $("#nsfw-filter-button a").click(function() {
-      $(this).parents('form').submit();
-      return false;
+    $("#nsfw-filter-button a").click(function () {
+        $(this).parents("form").submit();
+        return false;
     });
 
-    $("#apps .disconnect").click(function() {
-      if (confirm('Are you sure you want to disconnect this app?')) {
-        var $form = $(this).parent().next('form');
-        var url = $form.attr('action');
-        var data = $form.serialize();
-        var parent = $(this).parents('li');
-        $.post(url, data, function(response) {
-          parent.hide('slow');
-        }, 'ajax');
-        return false;
-      } else {
-        return false;
-      }
+    $("#apps .disconnect").click(function () {
+        if (confirm("Are you sure you want to disconnect this app?")) {
+            var $form = $(this).parent().next("form");
+            var url = $form.attr("action");
+            var data = $form.serialize();
+            var parent = $(this).parents("li");
+            $.post(
+                url,
+                data,
+                function (response) {
+                    parent.hide("slow");
+                },
+                "ajax",
+            );
+            return false;
+        } else {
+            return false;
+        }
     });
 
     // Tools: Find People / Shakes
     if ($("#content-find-people-body").length > 0) {
-      $("#content-find-people-body").load('/tools/find-shakes/quick-fetch-twitter');
-      $("#refresh-friends a").live('click', function() {
-        $("#content-find-people-body").load('/tools/find-shakes/quick-fetch-twitter?refresh=1');
-        return false;
-      });
+        $("#content-find-people-body").load(
+            "/tools/find-shakes/quick-fetch-twitter",
+        );
+        $("#refresh-friends a").live("click", function () {
+            $("#content-find-people-body").load(
+                "/tools/find-shakes/quick-fetch-twitter?refresh=1",
+            );
+            return false;
+        });
     }
 
     // Tools: Recommended group shakes
     if ($("#shake-categories").length > 0) {
-      var RecommendedShakeCategory = function(root) {
-        this.root = root;
-        this.$root = $(root);
-        this.fetched = false;
-        this.init_events();
-      };
+        var RecommendedShakeCategory = function (root) {
+            this.root = root;
+            this.$root = $(root);
+            this.fetched = false;
+            this.init_events();
+        };
 
-      $.extend(RecommendedShakeCategory.prototype, {
+        $.extend(RecommendedShakeCategory.prototype, {
+            init_events: function () {
+                this.$toggle = this.$root.find(".shake-category-toggle");
+                this.$body = this.$root.find(".shake-category-body");
+                this.$toggle.click($.proxy(this.click_toggle, this));
+            },
 
-        init_events: function() {
-          this.$toggle = this.$root.find('.shake-category-toggle');
-          this.$body = this.$root.find('.shake-category-body');
-          this.$toggle.click($.proxy(this.click_toggle, this));
+            click_toggle: function () {
+                if (!this.fetched) {
+                    var url =
+                        "/tools/find-shakes/quick-fetch-category/" +
+                        this.$toggle.attr("href").replace("#", "");
+                    $.get(url, $.proxy(this.populate_results, this));
+                } else {
+                    this.toggle();
+                }
+                return false;
+            },
 
-        },
+            populate_results: function (results) {
+                this.fetched = true;
+                this.$body.html(results);
+                this.toggle();
+            },
 
-        click_toggle: function() {
-          if (!this.fetched) {
-            var url = '/tools/find-shakes/quick-fetch-category/' + this.$toggle.attr('href').replace('#', '');
-            $.get(url, $.proxy(this.populate_results, this));
-          } else {
-            this.toggle();
-          }
-          return false;
-        },
+            toggle: function (result) {
+                this.$root.toggleClass("shake-category-selected");
+            },
+        });
 
-        populate_results: function(results) {
-          this.fetched = true;
-          this.$body.html(results);
-          this.toggle();
-        },
-
-        toggle: function(result) {
-          this.$root.toggleClass('shake-category-selected');
-        }
-
-      });
-
-
-      $("#shake-categories .shake-category").each(function() {
-        var new_category = new RecommendedShakeCategory(this)
-      });
+        $("#shake-categories .shake-category").each(function () {
+            var new_category = new RecommendedShakeCategory(this);
+        });
     }
 
     // Shake Page - change image.
-    $("#shake-image-edit").hover(function() {
-      $(this).addClass('shake-image-hover');
-    }, function() {
-      $(this).removeClass('shake-image-hover');
-    });
+    $("#shake-image-edit").hover(
+        function () {
+            $(this).addClass("shake-image-hover");
+        },
+        function () {
+            $(this).removeClass("shake-image-hover");
+        },
+    );
 
     // Shake Page: choosing file to upload.
-    $("#shake-image-edit input").change(function() {
-      $(this).closest("form").submit();
+    $("#shake-image-edit input").change(function () {
+        $(this).closest("form").submit();
     });
 
     // Shake Page: inline editing title & description:
-    $(".shake-edit-title-form .cancel").click(function() {
-      $(this).parents('.shake-details').find(".shake-edit-title").show();
-      $(this).closest(".shake-edit-title-form").hide();
-      return false;
+    $(".shake-edit-title-form .cancel").click(function () {
+        $(this).parents(".shake-details").find(".shake-edit-title").show();
+        $(this).closest(".shake-edit-title-form").hide();
+        return false;
     });
 
-    $(".shake-edit-title").hover(function() {
-      $(this).addClass('shake-edit-title-hover');
-    }, function() {
-      $(this).removeClass('shake-edit-title-hover');
+    $(".shake-edit-title").hover(
+        function () {
+            $(this).addClass("shake-edit-title-hover");
+        },
+        function () {
+            $(this).removeClass("shake-edit-title-hover");
+        },
+    );
+
+    $(".shake-edit-title").click(function () {
+        var $title_container = $(this).closest(".shake-details");
+        var url = $title_container.find("form").attr("action");
+        var that = this;
+
+        $.get(
+            url,
+            function (result) {
+                if ("title_raw" in result) {
+                    $(that).hide();
+                    $title_container
+                        .find(".shake-edit-title-input")
+                        .val(result["title_raw"]);
+                    $(that).next(".shake-edit-title-form").show();
+                }
+            },
+            "json",
+        );
     });
 
-    $(".shake-edit-title").click(function() {
-      var $title_container = $(this).closest('.shake-details');
-      var url = $title_container.find('form').attr('action');
-      var that = this;
-
-      $.get(url, function(result) {
-        if ('title_raw' in result) {
-          $(that).hide();
-          $title_container.find('.shake-edit-title-input').val(result['title_raw']);
-          $(that).next(".shake-edit-title-form").show();
-        }
-      }, 'json');
-
+    $(".shake-edit-title-form").submit(function () {
+        var data = $(this).serialize();
+        var url = $(this).attr("action");
+        var that = this;
+        $.post(
+            url,
+            data,
+            function (result) {
+                if ("title" in result && "title_raw" in result) {
+                    var $title_container = $(that).closest(".shake-details");
+                    $title_container
+                        .find(".shake-edit-title")
+                        .html(result["title"])
+                        .show();
+                    $title_container
+                        .find(".shake-edit-title-input")
+                        .val(result["title_raw"]);
+                    $title_container.find(".shake-edit-title-form").hide();
+                }
+            },
+            "json",
+        );
+        return false;
     });
-
-    $(".shake-edit-title-form").submit(function() {
-      var data = $(this).serialize();
-      var url = $(this).attr('action');
-      var that = this;
-      $.post(url, data, function (result){
-        if ('title' in result && 'title_raw' in result) {
-          var $title_container = $(that).closest('.shake-details');
-          $title_container.find('.shake-edit-title').html(result['title']).show();
-          $title_container.find('.shake-edit-title-input').val(result['title_raw']);
-          $title_container.find('.shake-edit-title-form').hide();
-        }
-      }, 'json');
-      return false;
-    });
-
 
     // Shake Page: Edit Description
-    $(".shake-edit-description-form .cancel").click(function() {
-      $(this).parents('.shake-details').find(".shake-edit-description").show();
-      $(this).closest(".shake-edit-description-form").hide();
-      return false;
+    $(".shake-edit-description-form .cancel").click(function () {
+        $(this)
+            .parents(".shake-details")
+            .find(".shake-edit-description")
+            .show();
+        $(this).closest(".shake-edit-description-form").hide();
+        return false;
     });
 
-    $(".shake-edit-description").hover(function() {
-      $(this).addClass('shake-edit-description-hover');
-    }, function() {
-      $(this).removeClass('shake-edit-description-hover');
+    $(".shake-edit-description").hover(
+        function () {
+            $(this).addClass("shake-edit-description-hover");
+        },
+        function () {
+            $(this).removeClass("shake-edit-description-hover");
+        },
+    );
+
+    $(".shake-edit-description").click(function () {
+        var $title_container = $(this).closest(".shake-details");
+        var url = $title_container.find("form").attr("action");
+        var that = this;
+
+        $.get(
+            url,
+            function (result) {
+                if ("description_raw" in result) {
+                    $(that).hide();
+                    $title_container
+                        .find(".shake-edit-description-input")
+                        .val(result["description_raw"]);
+                    $(that).next(".shake-edit-description-form").show();
+                }
+            },
+            "json",
+        );
     });
 
-    $(".shake-edit-description").click(function() {
-      var $title_container = $(this).closest('.shake-details');
-      var url = $title_container.find('form').attr('action');
-      var that = this;
-
-      $.get(url, function(result) {
-        if ('description_raw' in result) {
-          $(that).hide();
-          $title_container.find('.shake-edit-description-input').val(result['description_raw']);
-          $(that).next(".shake-edit-description-form").show();
-        }
-      }, 'json');
-
-    });
-
-    $(".shake-edit-description-form").submit(function() {
-      var data = $(this).serialize();
-      var url = $(this).attr('action');
-      var that = this;
-      $.post(url, data, function (result){
-        if ('description' in result && 'description_raw' in result) {
-          var $title_container = $(that).closest('.shake-details');
-          $title_container.find('.shake-edit-description').html(result['description']).show();
-          $title_container.find('.shake-edit-description-input').val(result['description_raw']);
-          $title_container.find('.shake-edit-description-form').hide();
-        }
-      }, 'json');
-      return false;
+    $(".shake-edit-description-form").submit(function () {
+        var data = $(this).serialize();
+        var url = $(this).attr("action");
+        var that = this;
+        $.post(
+            url,
+            data,
+            function (result) {
+                if ("description" in result && "description_raw" in result) {
+                    var $title_container = $(that).closest(".shake-details");
+                    $title_container
+                        .find(".shake-edit-description")
+                        .html(result["description"])
+                        .show();
+                    $title_container
+                        .find(".shake-edit-description-input")
+                        .val(result["description_raw"]);
+                    $title_container
+                        .find(".shake-edit-description-form")
+                        .hide();
+                }
+            },
+            "json",
+        );
+        return false;
     });
 
     var $user_counts = $("#user-counts");
     if ($user_counts.length > 0) {
+        var UserCounts = (function () {
+            var $root = $user_counts,
+                name = $root.attr("name");
+            $.get(
+                "/user/" + name + "/counts",
+                function (result) {
+                    UserCounts.display_results(result);
+                },
+                "json",
+            );
 
-      var UserCounts = function(){
-        var $root = $user_counts,
-            name = $root.attr('name');
-        $.get('/user/' + name + '/counts', function(result) { UserCounts.display_results(result); }, 'json');
-
-        return {
-          display_results: function(result) {
-            if ('views' in result) {
-              $root.find('.views .num').html(UserCounts.format(result['views']));
-              $root.find('.saves .num').html(UserCounts.format(result['saves']));
-              $root.find('.likes .num').html(UserCounts.format(result['likes']));
-            }
-          },
-          format: function(str_num) {
-            var rgx = /(\d+)(\d{3})/;
-            str_num = "" + str_num;
-            while (rgx.test(str_num)) {
-              str_num = str_num.replace(rgx, '$1' + ',' + '$2');
-            }
-            return str_num;
-          }
-        };
-      }();
-
+            return {
+                display_results: function (result) {
+                    if ("views" in result) {
+                        $root
+                            .find(".views .num")
+                            .html(UserCounts.format(result["views"]));
+                        $root
+                            .find(".saves .num")
+                            .html(UserCounts.format(result["saves"]));
+                        $root
+                            .find(".likes .num")
+                            .html(UserCounts.format(result["likes"]));
+                    }
+                },
+                format: function (str_num) {
+                    var rgx = /(\d+)(\d{3})/;
+                    str_num = "" + str_num;
+                    while (rgx.test(str_num)) {
+                        str_num = str_num.replace(rgx, "$1" + "," + "$2");
+                    }
+                    return str_num;
+                },
+            };
+        })();
     }
 
     /* Shake Page: Request invitation to shake */
-    var RequestInvitation = function($root) {
-      this.$root = $root;
-      this.init_dom();
-      this.init_events();
+    var RequestInvitation = function ($root) {
+        this.$root = $root;
+        this.init_dom();
+        this.init_events();
     };
 
     $.extend(RequestInvitation.prototype, {
-      init_dom: function() {
-        this.$form = this.$root.find('form');
-      },
+        init_dom: function () {
+            this.$form = this.$root.find("form");
+        },
 
-      init_events: function() {
-        this.$root.delegate('form', 'submit', $.proxy(this.submit_request, this));
-      },
+        init_events: function () {
+            this.$root.delegate(
+                "form",
+                "submit",
+                $.proxy(this.submit_request, this),
+            );
+        },
 
-      submit_request: function() {
-        var url =this.$form.attr('action');
-        var data = this.$form.serialize();
-        $.post(url, data, $.proxy(this.process_response, this));
-        return false;
-      },
+        submit_request: function () {
+            var url = this.$form.attr("action");
+            var data = this.$form.serialize();
+            $.post(url, data, $.proxy(this.process_response, this));
+            return false;
+        },
 
-      process_response: function() {
-        this.$root.html('<span>Ok! Request sent.</span>')
-      }
-
+        process_response: function () {
+            this.$root.html("<span>Ok! Request sent.</span>");
+        },
     });
-
 
     var $request_invitation = $("#request-invitation");
     if ($request_invitation.length > 0) {
-      request_invitation = new RequestInvitation($request_invitation);
+        request_invitation = new RequestInvitation($request_invitation);
     }
 
     // Button to remove from shake.
-    $(".remove-from-shake").click(function() {
-      $form = $(this).find('form').submit();
-      return false;
+    $(".remove-from-shake").click(function () {
+        $form = $(this).find("form").submit();
+        return false;
     });
 
     //make incoming clickable (I know.)
-    $('.incoming-header').click(function(){
-        document.location = document.location.protocol + '//' + document.location.host + '/incoming';
-
+    $(".incoming-header").click(function () {
+        document.location =
+            document.location.protocol +
+            "//" +
+            document.location.host +
+            "/incoming";
     });
 
-
     // Invite Member widget for the Shake administrator.
-    var InviteMember = function() {
-      var $main_module = $("#shake-invite-member");
-      var $input_field = $main_module.find('.input-text');
-      var $invite_button = $main_module.find('.invite-button');
-      var $shake_results = $main_module.find('.shake-results');
-      var $form = $main_module.find('form');
-      var $title = $main_module.find('h3');
-      var search_results = [];
-      var last_search = "";
+    var InviteMember = (function () {
+        var $main_module = $("#shake-invite-member");
+        var $input_field = $main_module.find(".input-text");
+        var $invite_button = $main_module.find(".invite-button");
+        var $shake_results = $main_module.find(".shake-results");
+        var $form = $main_module.find("form");
+        var $title = $main_module.find("h3");
+        var search_results = [];
+        var last_search = "";
 
-      $input_field.keyup(function(ev) {
-        InviteMember.search_names(ev);
-      });
+        $input_field.keyup(function (ev) {
+            InviteMember.search_names(ev);
+        });
 
-      $form.submit(function(ev) {
-        return InviteMember.submit_form();
-      });
+        $form.submit(function (ev) {
+            return InviteMember.submit_form();
+        });
 
-      $shake_results.click(function(ev) {
-        InviteMember.select_user($(ev.target).text());
-      });
+        $shake_results.click(function (ev) {
+            InviteMember.select_user($(ev.target).text());
+        });
 
-      $invite_button.click(function() {
-        InviteMember.send_invite();
-        return false;
-      });
-
-      return {
-        search_names: function() {
-          if ($input_field.val() == '') {
-            this.clear_results();
-            this.clear_input();
+        $invite_button.click(function () {
+            InviteMember.send_invite();
             return false;
-          }
+        });
 
-          // don't search again if field hasn't changed.
-          if ($input_field.val() == last_search) {
-            return false;
-          }
+        return {
+            search_names: function () {
+                if ($input_field.val() == "") {
+                    this.clear_results();
+                    this.clear_input();
+                    return false;
+                }
 
-          last_search = $input_field.val();
-          var data = $form.serialize();
-          var that = this;
-          $.post('/account/quick_name_search', data, function(response) {
-             if ('users' in response) {
-               that.update_results(response['users']);
-             }
-          }, 'json');
-        },
+                // don't search again if field hasn't changed.
+                if ($input_field.val() == last_search) {
+                    return false;
+                }
 
-        update_results: function(users) {
-          search_results = users
-          if (search_results.length == 0) {
-            this.clear_results();
-           } else {
-             this.render_results();
-           }
-        },
+                last_search = $input_field.val();
+                var data = $form.serialize();
+                var that = this;
+                $.post(
+                    "/account/quick_name_search",
+                    data,
+                    function (response) {
+                        if ("users" in response) {
+                            that.update_results(response["users"]);
+                        }
+                    },
+                    "json",
+                );
+            },
 
-        render_results: function() {
-          $shake_results.html('').show();
-          for (var i = 0; i < search_results.length; i++) {
-            $shake_results.append('<li><img src="'+ search_results[i].profile_image_url + '" width="24" height="24"><span>' + search_results[i].name + '</span></li>');
-          }
-        },
+            update_results: function (users) {
+                search_results = users;
+                if (search_results.length == 0) {
+                    this.clear_results();
+                } else {
+                    this.render_results();
+                }
+            },
 
-        select_user: function(user_name) {
-          this.clear_results();
-          $input_field.val(user_name);
-          $invite_button.removeAttr('disabled');
-        },
+            render_results: function () {
+                $shake_results.html("").show();
+                for (var i = 0; i < search_results.length; i++) {
+                    $shake_results.append(
+                        '<li><img src="' +
+                            search_results[i].profile_image_url +
+                            '" width="24" height="24"><span>' +
+                            search_results[i].name +
+                            "</span></li>",
+                    );
+                }
+            },
 
-        submit_form: function(ev) {
-          if (search_results.length == 1 && search_results[0].name == $input_field.val()) {
-            this.select_user(search_results[0].name);
-            this.send_invite();
-            this.clear_results();
-          }
-          return false;
-        },
+            select_user: function (user_name) {
+                this.clear_results();
+                $input_field.val(user_name);
+                $invite_button.removeAttr("disabled");
+            },
 
-        clear_results: function() {
-          last_search = "";
-          $shake_results.hide().html('');
-        },
+            submit_form: function (ev) {
+                if (
+                    search_results.length == 1 &&
+                    search_results[0].name == $input_field.val()
+                ) {
+                    this.select_user(search_results[0].name);
+                    this.send_invite();
+                    this.clear_results();
+                }
+                return false;
+            },
 
-        clear_input: function() {
-          $input_field.val('');
-          $invite_button.attr('disabled', 'disabled');
-        },
+            clear_results: function () {
+                last_search = "";
+                $shake_results.hide().html("");
+            },
 
-        send_invite: function() {
-          if ($invite_button.disabled) {
-            return false;
-          } else {
-            var url = $form.attr('action');
-            var data = $form.serialize();
-            $.post(url, data, function() {
-              InviteMember.data_sent();
-              return false;
-            }, 'json');
-            return false;
-          }
-        },
+            clear_input: function () {
+                $input_field.val("");
+                $invite_button.attr("disabled", "disabled");
+            },
 
-        data_sent: function() {
-          $title.html('Your invitation has been sent');
-          this.clear_input();
-          this.clear_results();
-        }
-      }
-    }();
+            send_invite: function () {
+                if ($invite_button.disabled) {
+                    return false;
+                } else {
+                    var url = $form.attr("action");
+                    var data = $form.serialize();
+                    $.post(
+                        url,
+                        data,
+                        function () {
+                            InviteMember.data_sent();
+                            return false;
+                        },
+                        "json",
+                    );
+                    return false;
+                }
+            },
 
+            data_sent: function () {
+                $title.html("Your invitation has been sent");
+                this.clear_input();
+                this.clear_results();
+            },
+        };
+    })();
 
     /* Shake Page: Remove Members From Shake */
-    var ShakeMemberList = function($root) {
-      this.$root = $root;
-      this.init_events();
+    var ShakeMemberList = function ($root) {
+        this.$root = $root;
+        this.init_events();
     };
 
     $.extend(ShakeMemberList.prototype, {
-      init_events: function() {
-        this.$root.delegate('.remove-from-shake-button-link', 'click', $.proxy(this.remove_from_shake, this));
-      },
+        init_events: function () {
+            this.$root.delegate(
+                ".remove-from-shake-button-link",
+                "click",
+                $.proxy(this.remove_from_shake, this),
+            );
+        },
 
-      remove_from_shake: function(ev) {
-        var $target = $(ev.target),
-            $li = $target.parents("li"),
-            $form = $target.next(),
-            url = $form.attr('action');
+        remove_from_shake: function (ev) {
+            var $target = $(ev.target),
+                $li = $target.parents("li"),
+                $form = $target.next(),
+                url = $form.attr("action");
             data = $form.serialize();
 
-        if (confirm("Are you sure you want to remove this user from a shake? If they have notifications on an email will be sent informing them of the change.")) {
-          $.post(url, data, $.proxy(this.process_remove, $li));
-        }
-        return false;
-      },
+            if (
+                confirm(
+                    "Are you sure you want to remove this user from a shake? If they have notifications on an email will be sent informing them of the change.",
+                )
+            ) {
+                $.post(url, data, $.proxy(this.process_remove, $li));
+            }
+            return false;
+        },
 
-      process_remove: function(response) {
-        this.remove();
-      }
+        process_remove: function (response) {
+            this.remove();
+        },
     });
 
     var $shake_member_list = $("#shake-members-list");
     if ($shake_member_list.length > 0) {
-      var shake_member_list = new ShakeMemberList($shake_member_list);
+        var shake_member_list = new ShakeMemberList($shake_member_list);
     }
 
     // support for dismissable "Vote 2020" banner; cookie naturally expires on Nov 4th
     var alertVote2020 = $("#alert-vote-2020");
-    var alertVote2020CookieVal = 'dismiss-alert-vote-2020=1';
-    var alertVote2020Expires = new Date('2020-11-04T00:00:00');
-    if (document.cookie.indexOf(alertVote2020CookieVal) === -1 &&
-      (new Date()) < alertVote2020Expires) {
-      alertVote2020.css({ display: 'block' });
-      alertVote2020.find('button').click(function() {
-        document.cookie = [
-          alertVote2020CookieVal,
-          'expires=' + alertVote2020Expires.toGMTString(),
-          'path=/'
-        ].join('; ');
-        alertVote2020.css({ display: 'none' });
-      });
+    var alertVote2020CookieVal = "dismiss-alert-vote-2020=1";
+    var alertVote2020Expires = new Date("2020-11-04T00:00:00");
+    if (
+        document.cookie.indexOf(alertVote2020CookieVal) === -1 &&
+        new Date() < alertVote2020Expires
+    ) {
+        alertVote2020.css({ display: "block" });
+        alertVote2020.find("button").click(function () {
+            document.cookie = [
+                alertVote2020CookieVal,
+                "expires=" + alertVote2020Expires.toGMTString(),
+                "path=/",
+            ].join("; ");
+            alertVote2020.css({ display: "none" });
+        });
     }
-
 });

--- a/static/js/p.js
+++ b/static/js/p.js
@@ -1,16 +1,16 @@
-function getEmbed(){
-   var e = window.frames["instacalc_bookmarklet_iframe"];
-   return e;
+function getEmbed() {
+    var e = window.frames["instacalc_bookmarklet_iframe"];
+    return e;
 }
 
-function addCSS(url){
-  var headID = document.getElementsByTagName("head")[0];
-  var cssNode = document.createElement('link');
-  cssNode.type = 'text/css';
-  cssNode.rel = 'stylesheet';
-  cssNode.href = url;
-  cssNode.media = 'screen';
-  headID.appendChild(cssNode);
+function addCSS(url) {
+    var headID = document.getElementsByTagName("head")[0];
+    var cssNode = document.createElement("link");
+    cssNode.type = "text/css";
+    cssNode.rel = "stylesheet";
+    cssNode.href = url;
+    cssNode.media = "screen";
+    headID.appendChild(cssNode);
 }
 
 /* Base64 encoding from http://ostermiller.org/calc/encode.html
@@ -28,28 +28,84 @@ Public License for more details.
 */
 var END_OF_INPUT = -1;
 var base64Chars = new Array(
-    'A','B','C','D','E','F','G','H',
-    'I','J','K','L','M','N','O','P',
-    'Q','R','S','T','U','V','W','X',
-    'Y','Z','a','b','c','d','e','f',
-    'g','h','i','j','k','l','m','n',
-    'o','p','q','r','s','t','u','v',
-    'w','x','y','z','0','1','2','3',
-    '4','5','6','7','8','9','+','/'
+    "A",
+    "B",
+    "C",
+    "D",
+    "E",
+    "F",
+    "G",
+    "H",
+    "I",
+    "J",
+    "K",
+    "L",
+    "M",
+    "N",
+    "O",
+    "P",
+    "Q",
+    "R",
+    "S",
+    "T",
+    "U",
+    "V",
+    "W",
+    "X",
+    "Y",
+    "Z",
+    "a",
+    "b",
+    "c",
+    "d",
+    "e",
+    "f",
+    "g",
+    "h",
+    "i",
+    "j",
+    "k",
+    "l",
+    "m",
+    "n",
+    "o",
+    "p",
+    "q",
+    "r",
+    "s",
+    "t",
+    "u",
+    "v",
+    "w",
+    "x",
+    "y",
+    "z",
+    "0",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "+",
+    "/",
 );
 
 var reverseBase64Chars = new Array();
-for (var i=0; i < base64Chars.length; i++){
+for (var i = 0; i < base64Chars.length; i++) {
     reverseBase64Chars[base64Chars[i]] = i;
 }
 
 var base64Str;
 var base64Count;
-function setBase64Str(str){
+function setBase64Str(str) {
     base64Str = str;
     base64Count = 0;
 }
-function readBase64(){    
+function readBase64() {
     if (!base64Str) return END_OF_INPUT;
     if (base64Count >= base64Str.length) return END_OF_INPUT;
     var c = base64Str.charCodeAt(base64Count) & 0xff;
@@ -58,74 +114,83 @@ function readBase64(){
 }
 
 /* make string URL safe; remove padding =, replace "+" and "/" with "*" and "-" */
-function encodeBase64ForURL(str){
-   var str = encodeBase64(str).replace(/=/g, "").replace(/\+/g, "*").replace(/\//g, "-");
-   str = str.replace(/\s/g, "");   /* Watch out! encodeBase64 breaks lines at 76 chars -- we don't want any whitespace */
-   return str;
+function encodeBase64ForURL(str) {
+    var str = encodeBase64(str)
+        .replace(/=/g, "")
+        .replace(/\+/g, "*")
+        .replace(/\//g, "-");
+    str = str.replace(
+        /\s/g,
+        "",
+    ); /* Watch out! encodeBase64 breaks lines at 76 chars -- we don't want any whitespace */
+    return str;
 }
 
 function keyPressHandler(e) {
-      var kC  = (window.event) ?    // MSIE or Firefox?
-                 event.keyCode : e.keyCode;
-      var Esc = (window.event) ?   
-                27 : e.DOM_VK_ESCAPE // MSIE : Firefox
-      if(kC==Esc){
-         // alert("Esc pressed");
-         toggleItem("instacalc_bookmarklet");
-      }
-}
-
-
-function toggleItem(id){
-  var item = document.getElementById(id);
-  if(item){
-    if ( item.style.display == "none"){
-      item.style.display = "";
+    var kC = window.event // MSIE or Firefox?
+        ? event.keyCode
+        : e.keyCode;
+    var Esc = window.event ? 27 : e.DOM_VK_ESCAPE; // MSIE : Firefox
+    if (kC == Esc) {
+        // alert("Esc pressed");
+        toggleItem("instacalc_bookmarklet");
     }
-    else{
-      item.style.display = "none";
-    } 
-  }
 }
 
-function showItem(id){
-  try{
+function toggleItem(id) {
     var item = document.getElementById(id);
-    if(item){
-        item.style.display = "";
+    if (item) {
+        if (item.style.display == "none") {
+            item.style.display = "";
+        } else {
+            item.style.display = "none";
+        }
     }
-  }
-  catch(e){
-  
-  }
 }
 
-(function(){
+function showItem(id) {
+    try {
+        var item = document.getElementById(id);
+        if (item) {
+            item.style.display = "";
+        }
+    } catch (e) {}
+}
 
-  var iframe_url = "http://localhost:8000/tools/p?url=" + encodeURIComponent(document.location.href);
+(function () {
+    var iframe_url =
+        "http://localhost:8000/tools/p?url=" +
+        encodeURIComponent(document.location.href);
 
- 
-  var existing_iframe = document.getElementById('instacalc_bookmarklet_iframe');
-  
-  if (existing_iframe){
-    showItem('instacalc_bookmarklet');
-    return;
-  }
-  
-  addCSS("http://localhost:8000/static/css/picker.css?x=" + (Math.random()));
- 
-  var div = document.createElement("div");
-  div.id = "instacalc_bookmarklet";
-  
-  var str = "";
-  str += "<table id='instacalc_bookmarklet_table' valign='top' width='570' cellspacing='0' cellpadding='0'><tr><td width ='550' height='80'>";
-  str += "<iframe frameborder='0' scrolling='no' name='instacalc_bookmarklet_iframe' id='instacalc_bookmarklet_iframe' src='" + iframe_url + "' width='550px' height='75px' style='textalign:right; backgroundColor: white;'></iframe>";
-  str += "</td><td onClick='toggleItem(\"instacalc_bookmarklet\");' style='background: #FFDDDD;' title='click to close window' valign='top' align='center' width='20px'>";
-  str += "<a href='javascript:void(0);' style='width:100%; text-align: middle; color: #FF0000; font-family: Arial;'>x</a>";
-  str += "</td></tr></table>";
-  
-  div.innerHTML = str;
-  
-  div.onkeypress = keyPressHandler;
-  document.body.insertBefore(div, document.body.firstChild);
-})()
+    var existing_iframe = document.getElementById(
+        "instacalc_bookmarklet_iframe",
+    );
+
+    if (existing_iframe) {
+        showItem("instacalc_bookmarklet");
+        return;
+    }
+
+    addCSS("http://localhost:8000/static/css/picker.css?x=" + Math.random());
+
+    var div = document.createElement("div");
+    div.id = "instacalc_bookmarklet";
+
+    var str = "";
+    str +=
+        "<table id='instacalc_bookmarklet_table' valign='top' width='570' cellspacing='0' cellpadding='0'><tr><td width ='550' height='80'>";
+    str +=
+        "<iframe frameborder='0' scrolling='no' name='instacalc_bookmarklet_iframe' id='instacalc_bookmarklet_iframe' src='" +
+        iframe_url +
+        "' width='550px' height='75px' style='textalign:right; backgroundColor: white;'></iframe>";
+    str +=
+        "</td><td onClick='toggleItem(\"instacalc_bookmarklet\");' style='background: #FFDDDD;' title='click to close window' valign='top' align='center' width='20px'>";
+    str +=
+        "<a href='javascript:void(0);' style='width:100%; text-align: middle; color: #FF0000; font-family: Arial;'>x</a>";
+    str += "</td></tr></table>";
+
+    div.innerHTML = str;
+
+    div.onkeypress = keyPressHandler;
+    document.body.insertBefore(div, document.body.firstChild);
+})();

--- a/static/js/paging_keys.js
+++ b/static/js/paging_keys.js
@@ -5,8 +5,8 @@ function HotKey(element) {
     this._keyfunc = {};
     this.init();
 }
-HotKey.kc2char = function(kc) {
-    var between = function(a, b) {
+HotKey.kc2char = function (kc) {
+    var between = function (a, b) {
         return a <= kc && kc <= b;
     };
     var _32_40 = "space pageup pagedown end home left up right down".split(" ");
@@ -16,7 +16,7 @@ HotKey.kc2char = function(kc) {
         13: "enter",
         16: "shift",
         17: "ctrl",
-        46: "delete"
+        46: "delete",
     };
     return between(65, 90)
         ? String.fromCharCode(kc + 32) // a-z
@@ -31,9 +31,9 @@ HotKey.kc2char = function(kc) {
         : null;
 };
 HotKey.prototype.ignore = /input|textarea/i;
-HotKey.prototype.init = function() {
+HotKey.prototype.init = function () {
     var self = this;
-    var listener = function(e) {
+    var listener = function (e) {
         self.onkeydown(e);
     };
     if (this.target.addEventListener) {
@@ -42,7 +42,7 @@ HotKey.prototype.init = function() {
         this.target.attachEvent("onkeydown", listener);
     }
 };
-HotKey.prototype.onkeydown = function(e) {
+HotKey.prototype.onkeydown = function (e) {
     var tag = (e.target || e.srcElement).tagName;
     if (this.ignore.test(tag)) return;
     if (e.metaKey) return;
@@ -58,29 +58,29 @@ HotKey.prototype.onkeydown = function(e) {
         this._keyfunc[input].call(this, e);
     }
 };
-HotKey.prototype.sendKey = function(key) {
+HotKey.prototype.sendKey = function (key) {
     this._keyfunc[key] && this._keyfunc[key]();
 };
-HotKey.prototype.add = function(key, func) {
+HotKey.prototype.add = function (key, func) {
     if (key.constructor == Array) {
         for (var i = 0; i < key.length; i++) this._keyfunc[key[i]] = func;
     } else {
         this._keyfunc[key] = func;
     }
 };
-HotKey.prototype.remove = function(key) {
+HotKey.prototype.remove = function (key) {
     if (key.constructor == Array) {
         for (var i = 0; i < key.length; i++)
-            this._keyfunc[key[i]] = function() {};
+            this._keyfunc[key[i]] = function () {};
     } else {
-        this._keyfunc[key] = function() {};
+        this._keyfunc[key] = function () {};
     }
 };
 
 /* https://github.com/matthutchinson/paging_keys_js - inspired by navigation on ffffound.com UI */
 /* by Matthew Hutchinson - matthutchinson.net */
 
-var pagingKeys = (function() {
+var pagingKeys = (function () {
     // settings
     var config = {
         nodeSelector: ".image-title", // used to select each item on the page and place in the map (must be a link)
@@ -93,7 +93,7 @@ var pagingKeys = (function() {
         keyPrevPage: "l",
         keyRefresh: "r",
         additionalBodyClass: "paging-keys", // this class is assigned to the page body on load
-        bottomAnchor: "bottom" // the name of the anchor (without #) at end of page, e.g. set on last post on the page
+        bottomAnchor: "bottom", // the name of the anchor (without #) at end of page, e.g. set on last post on the page
     };
 
     var item_map = [];
@@ -105,7 +105,7 @@ var pagingKeys = (function() {
     // jquery
 
     function windowScrollInit() {
-        $(window).scroll(function() {
+        $(window).scroll(function () {
             positionNav();
         });
     }
@@ -115,7 +115,7 @@ var pagingKeys = (function() {
             w: $(window).width(),
             h: $(window).height(),
             x: $(window).scrollLeft(),
-            y: $(window).scrollTop()
+            y: $(window).scrollTop(),
         };
     }
 
@@ -132,7 +132,7 @@ var pagingKeys = (function() {
         $("#" + config.pagingNavId).css({
             position: "absolute",
             right: "10px",
-            top: getScrollTop() + 10 + "px"
+            top: getScrollTop() + 10 + "px",
         });
     }
 
@@ -180,7 +180,7 @@ var pagingKeys = (function() {
             addItemToMap(nodes[i]);
         }
         // sort based on page Y postion
-        item_map.sort(function(a, b) {
+        item_map.sort(function (a, b) {
             return a.y - b.y;
         });
 
@@ -203,24 +203,24 @@ var pagingKeys = (function() {
             hot_key = new HotKey();
         } catch (e) {
             alert(
-                "Oops, paging_keys requires HotKeys.js (http://la.ma.la/blog/diary_200511041713.htm)"
+                "Oops, paging_keys requires HotKeys.js (http://la.ma.la/blog/diary_200511041713.htm)",
             );
             alert(e);
         }
         if (hot_key) {
-            hot_key.add(config.keyNext, function() {
+            hot_key.add(config.keyNext, function () {
                 moveToItem(1);
             });
-            hot_key.add(config.keyPrev, function() {
+            hot_key.add(config.keyPrev, function () {
                 moveToItem(-1);
             });
-            hot_key.add(config.keyNextPage, function() {
+            hot_key.add(config.keyNextPage, function () {
                 movePage(1);
             });
-            hot_key.add(config.keyPrevPage, function() {
+            hot_key.add(config.keyPrevPage, function () {
                 movePage(-1);
             });
-            hot_key.add(config.keyRefresh, function() {
+            hot_key.add(config.keyRefresh, function () {
                 location.reload();
             });
         }
@@ -308,7 +308,7 @@ var pagingKeys = (function() {
             height: sh,
             clientHeight: ch,
             is_at_top: st == 0 && sl == 0,
-            is_at_last: st + ch == sh && sl == 0
+            is_at_last: st + ch == sh && sl == 0,
         };
     }
 
@@ -341,7 +341,7 @@ var pagingKeys = (function() {
                 redirect(
                     getEl(config.prevPageSelector)[0].href +
                         "#" +
-                        config.bottomAnchor
+                        config.bottomAnchor,
                 );
                 disableHotKeys();
                 return true;
@@ -358,7 +358,7 @@ var pagingKeys = (function() {
         movePage: movePage,
         currentItem: currentItem,
         config: config,
-        item_map: item_map
+        item_map: item_map,
     };
 })();
 

--- a/static/js/portal.jquery.js
+++ b/static/js/portal.jquery.js
@@ -1,152 +1,161 @@
 /*
  * Portal 0.2
- * 
- * Conceived by Andre Torrez (@torrez) in his dreams. 
- * 
+ *
+ * Conceived by Andre Torrez (@torrez) in his dreams.
+ *
  */
 
-(function($) {
-    
-  var Portal = function(el, settings) {
-    this.start_click_x = 0;
-    this.start_click_y = 0;
-    this.end_click_x = 0;
-    this.end_click_y = 0;
-    this.settings = settings;
-    
-    this.element = el;
-    this.$element = $(el);
-    this.ctx = this.element.getContext('2d');
-    
-    // calculate height width of drawable area.
-    // make sure height & width attributes are set on
-    // canvas element, otherwise we get deformed drawing.
-    this.height = this.$element.height();
-    this.width = this.$element.width();
-    this.$element.attr('height', this.height);
-    this.$element.attr('width', this.width);    
-  };
-  
-  Portal.prototype.getEventPosition = function(e) {
-    var left = 0;
-    var top = 0;
-    if (typeof e.touches != 'undefined' && typeof e.touches[0] != 'undefined') {
-      left = e.touches[0].pageX - this.$element.offset().left;
-      top = e.touches[0].pageY - this.$element.offset().top;      
-    }
-    else if (typeof e.changedTouches != 'undefined' && typeof e.changedTouches[0] != 'udefined') {
-      left = e.changedTouches[0].pageX - this.$element.offset().left;
-      top = e.changedTouches[0].pageY - this.$element.offset().top;      
-    } else {
-      left = e.pageX - this.$element.offset().left;
-      top = e.pageY - this.$element.offset().top;
-    }
-    return {'left': left, 'top': top};
-  };
-  
-  Portal.prototype.drawPortal = function(depressed) {          
-    var width_x = Math.abs(this.start_click_x - this.end_click_x);
-    var width_y = Math.abs(this.start_click_y - this.end_click_y);
-    var reverse_x = (this.end_click_x < this.start_click_x) ? -1 : 1;
-    var reverse_y = (this.end_click_y > this.start_click_y) ? 1 : -1;
-    
-    var x = this.start_click_x + (width_x / 2) * reverse_x;
-    var y = this.start_click_y + (width_y / 2) * reverse_y;
-    var radius = width_x / 2;
-    
-    this.clearCanvas();
-    if (!depressed) {
-      this.ctx.fillStyle = this.settings['button-side-color'];
-      this.ctx.strokeStyle = this.settings['button-side-color'];
-              
-      for (var i = 0; i <= 10; i++) {
-        this.ctx.beginPath();
-        this.ctx.arc(x, y + i, radius, 0, Math.PI*2, true);
-        this.ctx.fill();
-      }
-      
-      this.ctx.beginPath();
-      this.ctx.fillStyle = this.settings['button-top-color'];
-      this.ctx.strokeStyle = this.settings['button-top-color'];
-      this.ctx.arc(x, y, radius, 0, Math.PI*2, true);
-      this.ctx.fill();
-      
-    } else {
-      this.ctx.beginPath();
-      this.ctx.fillStyle = this.settings['button-top-color'];
-      this.ctx.strokeStyle = this.settings['button-top-color'];
-      this.ctx.arc(x, y + 10, radius, 0, Math.PI*2, true);
-      this.ctx.fill();
-    }
-  };
-  
-  Portal.prototype.clearCanvas = function() {
-    this.ctx.clearRect(0, 0,this.width,this.height);
-  };  
-  
-  Portal.prototype.pointInCircle = function(x, y) {
-    return this.ctx.isPointInPath(x, y);
-  };
-    
-  // Setup events.
-  Portal.prototype.init = function() {
-    var that = this;
-    
-    // Start Action
-    this.$element.mousedown(function(e) {
-      that.startAction(e);
-    });
-    this.element.addEventListener('touchstart', function(e) {
-      that.startAction(e);
-    }, false);
-        
-    // End Action
-    this.element.addEventListener('touchend', function(e) {
-      that.endAction(e);
-    }, false);
-    $(document).mouseup(function(e) {
-      that.endAction(e);
-    });
-    
-  };
+(function ($) {
+    var Portal = function (el, settings) {
+        this.start_click_x = 0;
+        this.start_click_y = 0;
+        this.end_click_x = 0;
+        this.end_click_y = 0;
+        this.settings = settings;
 
-  Portal.prototype.startAction = function(e) {
-    var position = this.getEventPosition(e);
-    if (this.pointInCircle(position.left, position.top)) {
-      this.drawPortal(true);
-      this.settings.callback();          
-    } else {
-      this.start_click_x = position.left;
-      this.start_click_y = position.top;
-    }
-  };
-  
-  Portal.prototype.endAction = function(e) {
-    var position = this.getEventPosition(e);
-    if (this.pointInCircle(position.left, position.top)) {
-      this.drawPortal();
-    } else {
-      this.end_click_x = position.left;
-      this.end_click_y = position.top;
-      this.drawPortal();
-    }
-  };
+        this.element = el;
+        this.$element = $(el);
+        this.ctx = this.element.getContext("2d");
 
-  $.fn.portal = function(options) {
-    var defaults = {
-      'button-top-color' : '#999',
-      'button-side-color' : '#666',
-      'callback' : (function() {})
+        // calculate height width of drawable area.
+        // make sure height & width attributes are set on
+        // canvas element, otherwise we get deformed drawing.
+        this.height = this.$element.height();
+        this.width = this.$element.width();
+        this.$element.attr("height", this.height);
+        this.$element.attr("width", this.width);
     };
-        
-    if (options) {
-      $.extend(defaults, options);
-    }
-    
-    return this.each(function() {
-      var portal = new Portal(this, defaults);
-      portal.init();
-    });
-  };
-  
+
+    Portal.prototype.getEventPosition = function (e) {
+        var left = 0;
+        var top = 0;
+        if (
+            typeof e.touches != "undefined" &&
+            typeof e.touches[0] != "undefined"
+        ) {
+            left = e.touches[0].pageX - this.$element.offset().left;
+            top = e.touches[0].pageY - this.$element.offset().top;
+        } else if (
+            typeof e.changedTouches != "undefined" &&
+            typeof e.changedTouches[0] != "udefined"
+        ) {
+            left = e.changedTouches[0].pageX - this.$element.offset().left;
+            top = e.changedTouches[0].pageY - this.$element.offset().top;
+        } else {
+            left = e.pageX - this.$element.offset().left;
+            top = e.pageY - this.$element.offset().top;
+        }
+        return { left: left, top: top };
+    };
+
+    Portal.prototype.drawPortal = function (depressed) {
+        var width_x = Math.abs(this.start_click_x - this.end_click_x);
+        var width_y = Math.abs(this.start_click_y - this.end_click_y);
+        var reverse_x = this.end_click_x < this.start_click_x ? -1 : 1;
+        var reverse_y = this.end_click_y > this.start_click_y ? 1 : -1;
+
+        var x = this.start_click_x + (width_x / 2) * reverse_x;
+        var y = this.start_click_y + (width_y / 2) * reverse_y;
+        var radius = width_x / 2;
+
+        this.clearCanvas();
+        if (!depressed) {
+            this.ctx.fillStyle = this.settings["button-side-color"];
+            this.ctx.strokeStyle = this.settings["button-side-color"];
+
+            for (var i = 0; i <= 10; i++) {
+                this.ctx.beginPath();
+                this.ctx.arc(x, y + i, radius, 0, Math.PI * 2, true);
+                this.ctx.fill();
+            }
+
+            this.ctx.beginPath();
+            this.ctx.fillStyle = this.settings["button-top-color"];
+            this.ctx.strokeStyle = this.settings["button-top-color"];
+            this.ctx.arc(x, y, radius, 0, Math.PI * 2, true);
+            this.ctx.fill();
+        } else {
+            this.ctx.beginPath();
+            this.ctx.fillStyle = this.settings["button-top-color"];
+            this.ctx.strokeStyle = this.settings["button-top-color"];
+            this.ctx.arc(x, y + 10, radius, 0, Math.PI * 2, true);
+            this.ctx.fill();
+        }
+    };
+
+    Portal.prototype.clearCanvas = function () {
+        this.ctx.clearRect(0, 0, this.width, this.height);
+    };
+
+    Portal.prototype.pointInCircle = function (x, y) {
+        return this.ctx.isPointInPath(x, y);
+    };
+
+    // Setup events.
+    Portal.prototype.init = function () {
+        var that = this;
+
+        // Start Action
+        this.$element.mousedown(function (e) {
+            that.startAction(e);
+        });
+        this.element.addEventListener(
+            "touchstart",
+            function (e) {
+                that.startAction(e);
+            },
+            false,
+        );
+
+        // End Action
+        this.element.addEventListener(
+            "touchend",
+            function (e) {
+                that.endAction(e);
+            },
+            false,
+        );
+        $(document).mouseup(function (e) {
+            that.endAction(e);
+        });
+    };
+
+    Portal.prototype.startAction = function (e) {
+        var position = this.getEventPosition(e);
+        if (this.pointInCircle(position.left, position.top)) {
+            this.drawPortal(true);
+            this.settings.callback();
+        } else {
+            this.start_click_x = position.left;
+            this.start_click_y = position.top;
+        }
+    };
+
+    Portal.prototype.endAction = function (e) {
+        var position = this.getEventPosition(e);
+        if (this.pointInCircle(position.left, position.top)) {
+            this.drawPortal();
+        } else {
+            this.end_click_x = position.left;
+            this.end_click_y = position.top;
+            this.drawPortal();
+        }
+    };
+
+    $.fn.portal = function (options) {
+        var defaults = {
+            "button-top-color": "#999",
+            "button-side-color": "#666",
+            callback: function () {},
+        };
+
+        if (options) {
+            $.extend(defaults, options);
+        }
+
+        return this.each(function () {
+            var portal = new Portal(this, defaults);
+            portal.init();
+        });
+    };
 })(jQuery);

--- a/static/js/tools.js
+++ b/static/js/tools.js
@@ -1,66 +1,61 @@
 /* JS for the tools page */
 
-(function($) {
+(function ($) {
+    $.fn.hint = function (text) {
+        var default_text = text;
+        var field = this;
+        var original_color = $(this).css("color");
 
-  $.fn.hint = function(text) {
+        var setDefault = function () {
+            if ($(field).val() == "") {
+                $(field).css("color", "#999").val(default_text);
+            }
+        };
 
-    var default_text = text;
-    var field = this;
-    var original_color = $(this).css('color');
+        var resetStyles = function () {
+            $(field).css("color", original_color);
+        };
 
-    var setDefault = function() {
-      if ($(field).val() == '') {
-        $(field).css('color', '#999').val(default_text);
-      }
+        var clearField = function () {
+            $(field).val("");
+        };
+
+        setDefault();
+
+        this.focus(function () {
+            if ($(this).val() == default_text) {
+                resetStyles();
+                clearField();
+            }
+        }).blur(function () {
+            setDefault();
+        });
+
+        // on submit, clear out the hint before submit.
+        this.parents("form:first").submit(function () {
+            if ($(field).val() == default_text) {
+                clearField();
+            }
+        });
+
+        return this;
     };
 
-    var resetStyles = function() {
-      $(field).css('color', original_color);
-    };
-
-    var clearField = function() {
-      $(field).val('');
-    };
-
-    setDefault();
-
-    this.focus(function() {
-      if ($(this).val() == default_text) {
-        resetStyles();
-        clearField();
-      }
-    }).blur(function() {
-      setDefault();
+    $(".picker-content .textarea-navigation .tab").click(function (e) {
+        let tabId = e.target.getAttribute("data-tab");
+        let tab = document.getElementById(tabId);
+        if (tab && !$(tab).hasClass("field-textarea--selected")) {
+            $(".picker-content .textarea-navigation li").removeClass(
+                "selected",
+            );
+            $(e.target).closest("li").addClass("selected");
+            $("#description").removeClass("field-textarea--selected");
+            $("#alt-text").removeClass("field-textarea--selected");
+            $(tab).addClass("field-textarea--selected");
+        }
     });
-
-    // on submit, clear out the hint before submit.
-    this.parents('form:first').submit(function() {
-      if ($(field).val() == default_text) {
-        clearField();
-      }
-    });
-
-    return this;
-  };
-
-  $('.picker-content .textarea-navigation .tab').click(function(e) {
-    let tabId = e.target.getAttribute('data-tab');
-    let tab = document.getElementById(tabId);
-    if (tab && !$(tab).hasClass('field-textarea--selected')) {
-      $('.picker-content .textarea-navigation li').removeClass('selected');
-      $(e.target).closest('li').addClass('selected');
-      $('#description').removeClass('field-textarea--selected');
-      $('#alt-text').removeClass('field-textarea--selected');
-      $(tab).addClass('field-textarea--selected');
-    }
-  });
-
-
 })(jQuery);
 
-
-$(document).ready(function() {
-
-  $('#description-field').hint('Write a description if you\'d like!');
-
+$(document).ready(function () {
+    $("#description-field").hint("Write a description if you'd like!");
 });

--- a/static/straw/source.js
+++ b/static/straw/source.js
@@ -9,235 +9,264 @@ Bookmarklet URL: javascript:void((function(){var%20e=document.createElement('scr
 java -jar ./tools/compiler.jar --js static/straw/source.js --js_output_file static/straw/compact.js
 */
 
-(function(global) {
-  'use strict';
-    
-  if (global.MLTSHPStraw !== undefined) {
-    global.MLTSHPStraw.toggle();
-    return;
-  }
-  
-  var Event = function(){
-    var event_listener = !!global.document.addEventListener;
-    
-    return {
-      bind: function(el, type, callback) {
-        var handler = function(e) {
-          return callback.apply(el, arguments);
+(function (global) {
+    "use strict";
+
+    if (global.MLTSHPStraw !== undefined) {
+        global.MLTSHPStraw.toggle();
+        return;
+    }
+
+    var Event = (function () {
+        var event_listener = !!global.document.addEventListener;
+
+        return {
+            bind: function (el, type, callback) {
+                var handler = function (e) {
+                    return callback.apply(el, arguments);
+                };
+
+                if (event_listener) {
+                    el.addEventListener(type, handler, false);
+                } else {
+                    el.attachEvent("on" + type, handler);
+                }
+            },
         };
-        
-        if (event_listener) {
-          el.addEventListener(type, handler, false);
-        } else {
-          el.attachEvent('on' + type, handler);
-        }
-      }
+    })();
+
+    var Proxy = function (callback, context) {
+        return function () {
+            callback.apply(context, arguments);
+        };
     };
-  }();
 
-  var Proxy = function(callback, context) {
-    return function() {
-      callback.apply(context, arguments);
-    }
-  };
-  
-  var DOM = {
-    style: function(el, property) {
-      var y = null;
-      if (el.currentStyle) {
-        y = el.currentStyle[property];
-      } else if (global.getComputedStyle) {
-        y = global.document.defaultView.getComputedStyle(el,null).getPropertyValue(property);
-      }
-      return y;
-    }
-  };
-  
-  var Sharedfile = function(category, asset, el) {
-    this.category = category;
-    this.asset = asset;
-    this.el = el;
-  };
-  
-  Sharedfile.prototype.append_root = global.document.body;
-    
-  Sharedfile.prototype.position = function() {
-    var el = this.el,
-        left = 0,
-        top = 0;
-    
-    do {
-      // Grab first relative container to use to append
-      // our overlays.
-      var style = DOM.style(el, 'position');
-      if (style == 'relative') {
-        this.append_root = el;
-        break;
-      }
-      
-      left += el.offsetLeft;
-      top += el.offsetTop;
-    } while (el = el.offsetParent)
+    var DOM = {
+        style: function (el, property) {
+            var y = null;
+            if (el.currentStyle) {
+                y = el.currentStyle[property];
+            } else if (global.getComputedStyle) {
+                y = global.document.defaultView
+                    .getComputedStyle(el, null)
+                    .getPropertyValue(property);
+            }
+            return y;
+        },
+    };
 
-    return [left, top];
-  };
-  
-  Sharedfile.prototype.hide = function() {
-    if (this.view !== undefined) {
-      this.view.style.display = 'none';
-    }
-  };
-  
-  Sharedfile.prototype.show = function() {
-    if (this.view !== undefined) {
-      this.view.style.display = 'block';
-    }
-  };
+    var Sharedfile = function (category, asset, el) {
+        this.category = category;
+        this.asset = asset;
+        this.el = el;
+    };
 
-  Sharedfile.prototype.draw_overlay = function() {
-    var position = this.position(),
-        width = this.width(),
-        height = this.height(),
-        div = document.createElement('div'),
-        append_root = this.append_root;
-    
-    div.className = 'mltshp-sf-overlay';
-    div.style.left = position[0] + "px";
-    div.style.top = position[1] + "px";
-    div.style.width = (width - 4) + "px";
-    div.style.height = (height - 4) + "px";
-    
-    if (width > 300 && height > 100) {
-      var left_margin = (width - 240) / 2,
-          top_margin = (height - 45) / 2;
-      html = '<span class="mltshp-sf-overlay-text" style="';
-      html = html + 'margin-top:' + top_margin + 'px;';
-      html = html + 'margin-left:' + left_margin + 'px;';
-      html = html + '">Save on MLTSHP</span>';
-      div.innerHTML = html;
-    }
-    
-    append_root.appendChild(div);
-    this.view = div;
-    Event.bind(div, 'click', Proxy(this.click_overlay, this));
-  };
-  
-  Sharedfile.prototype.click_overlay = function(ev) {
-    if (ev.stopPropagation) {
-      ev.stopPropagation();
-    } else {
-      ev.cancelBubble = true;
-    }
-    
-    left_location = screen.width/2-450;
-    top_location = screen.height/2-300;
-    var window_attributes = "width=850,height=650,menubar=yes,toolbar=yes,scrollbars=yes,resizable=yes,left=" + left_location + ",top=" + top_location + "screenX=" + left_location + ",screenY=" + top_location;
-    global.open('https://mltshp.com/tools/p?url=' + encodeURI(this.asset) + '&title=' + encodeURI(global.document.title) + '&source_url=' + encodeURI(global.location.href), 'save_image', window_attributes);
-  };
-  
-  Sharedfile.prototype.height = function() {
-    if (this._height === undefined) {
-      this._height = this.el.offsetHeight;
-    }
-    return this._height;
-  };
-  
-  Sharedfile.prototype.width = function() {
-    if (this._width === undefined) {
-      this._width = this.el.offsetWidth;
-    }
-    return this._width;
-  };
-    
-  
-  var AssetFinder = {
-    _parse_query: function(query) {
-      var split = query.split('&'),
-          split_length = split.length,
-          params = {};
+    Sharedfile.prototype.append_root = global.document.body;
 
-      for (var i = 0; i < split_length; i++) {
-        var param_value = split[i].split('=');
-        params[param_value[0]] = param_value[1];
-      }
-      
-      return params;
-    },
-    
-    videos: function() {
-      var embeds = document.getElementsByTagName('embed'),
-          embeds_length = embeds.length,
-          objects = document.getElementsByTagName('object'),
-          objects_length = objects.length,
-          found = [];
-      
-      for (var i = 0; i < embeds_length; i++) {
-        var embed = embeds[i],
-            flashvars = embed.getAttribute('flashvars');
-        if (flashvars) {
-          var params = this._parse_query(flashvars);
-          if (params['video_id']) {
-            found.push({'el' : embed, 'url' : 'http://www.youtube.com/watch?v=' + params['mJ1CSeNlRA4']})
-          }
+    Sharedfile.prototype.position = function () {
+        var el = this.el,
+            left = 0,
+            top = 0;
+
+        do {
+            // Grab first relative container to use to append
+            // our overlays.
+            var style = DOM.style(el, "position");
+            if (style == "relative") {
+                this.append_root = el;
+                break;
+            }
+
+            left += el.offsetLeft;
+            top += el.offsetTop;
+        } while ((el = el.offsetParent));
+
+        return [left, top];
+    };
+
+    Sharedfile.prototype.hide = function () {
+        if (this.view !== undefined) {
+            this.view.style.display = "none";
         }
-      }
-      
-      for (var i = 0; i < objects_length; i++) {
-        var object = objects[i];
-        var data = object.getAttribute('data');
-        if (data && data.indexOf('vimeocdn') > 0) {
-          var video_id = object.getAttribute('id').replace('player', '').split('_')[0];
-          found.push({'el' : object, 'url' : 'http://vimeo.com/' + video_id})
-        }
-      }
-      return found;
-    },
-    
-    images: function() {
-      var imgs = document.getElementsByTagName('img'),
-          imgs_length = imgs.length,
-          found = [];
-      for (var i = 0; i < imgs_length; i++) {
-        if (imgs[i].offsetWidth < 100 || imgs[i].offsetHeight < 100) {
-          continue;
-        }
-        found.push(imgs[i]);
-      }
-      return found;
-    }
-    
-  };
-  
-  global.MLTSHPStraw = {
-    found: [],
-    
-    init: function() {
-      this.initiated = true;
-      this.init_styles();
-      this.find_assets();
-      this.draw_overlays();
-    },
-  
-    find_assets: function() {
-      var images = AssetFinder.images(),
-          images_length = images.length,
-          videos = AssetFinder.videos(),
-          videos_length = videos.length,
-          found = []
-    
-      for (var i = 0; i < images_length; i++) {
-        found.push(new Sharedfile('image', images[i].src, images[i]));
-      }
+    };
 
-      //for (var i = 0; i < videos_length; i++) {
-      //  found.push(new Sharedfile('video', videos[i].url, videos[i].el));
-      //}
-      
-      this.found = found;
-    },
-  
-    init_styles: function() {
-      var style = "\
+    Sharedfile.prototype.show = function () {
+        if (this.view !== undefined) {
+            this.view.style.display = "block";
+        }
+    };
+
+    Sharedfile.prototype.draw_overlay = function () {
+        var position = this.position(),
+            width = this.width(),
+            height = this.height(),
+            div = document.createElement("div"),
+            append_root = this.append_root;
+
+        div.className = "mltshp-sf-overlay";
+        div.style.left = position[0] + "px";
+        div.style.top = position[1] + "px";
+        div.style.width = width - 4 + "px";
+        div.style.height = height - 4 + "px";
+
+        if (width > 300 && height > 100) {
+            var left_margin = (width - 240) / 2,
+                top_margin = (height - 45) / 2;
+            html = '<span class="mltshp-sf-overlay-text" style="';
+            html = html + "margin-top:" + top_margin + "px;";
+            html = html + "margin-left:" + left_margin + "px;";
+            html = html + '">Save on MLTSHP</span>';
+            div.innerHTML = html;
+        }
+
+        append_root.appendChild(div);
+        this.view = div;
+        Event.bind(div, "click", Proxy(this.click_overlay, this));
+    };
+
+    Sharedfile.prototype.click_overlay = function (ev) {
+        if (ev.stopPropagation) {
+            ev.stopPropagation();
+        } else {
+            ev.cancelBubble = true;
+        }
+
+        left_location = screen.width / 2 - 450;
+        top_location = screen.height / 2 - 300;
+        var window_attributes =
+            "width=850,height=650,menubar=yes,toolbar=yes,scrollbars=yes,resizable=yes,left=" +
+            left_location +
+            ",top=" +
+            top_location +
+            "screenX=" +
+            left_location +
+            ",screenY=" +
+            top_location;
+        global.open(
+            "https://mltshp.com/tools/p?url=" +
+                encodeURI(this.asset) +
+                "&title=" +
+                encodeURI(global.document.title) +
+                "&source_url=" +
+                encodeURI(global.location.href),
+            "save_image",
+            window_attributes,
+        );
+    };
+
+    Sharedfile.prototype.height = function () {
+        if (this._height === undefined) {
+            this._height = this.el.offsetHeight;
+        }
+        return this._height;
+    };
+
+    Sharedfile.prototype.width = function () {
+        if (this._width === undefined) {
+            this._width = this.el.offsetWidth;
+        }
+        return this._width;
+    };
+
+    var AssetFinder = {
+        _parse_query: function (query) {
+            var split = query.split("&"),
+                split_length = split.length,
+                params = {};
+
+            for (var i = 0; i < split_length; i++) {
+                var param_value = split[i].split("=");
+                params[param_value[0]] = param_value[1];
+            }
+
+            return params;
+        },
+
+        videos: function () {
+            var embeds = document.getElementsByTagName("embed"),
+                embeds_length = embeds.length,
+                objects = document.getElementsByTagName("object"),
+                objects_length = objects.length,
+                found = [];
+
+            for (var i = 0; i < embeds_length; i++) {
+                var embed = embeds[i],
+                    flashvars = embed.getAttribute("flashvars");
+                if (flashvars) {
+                    var params = this._parse_query(flashvars);
+                    if (params["video_id"]) {
+                        found.push({
+                            el: embed,
+                            url:
+                                "http://www.youtube.com/watch?v=" +
+                                params["mJ1CSeNlRA4"],
+                        });
+                    }
+                }
+            }
+
+            for (var i = 0; i < objects_length; i++) {
+                var object = objects[i];
+                var data = object.getAttribute("data");
+                if (data && data.indexOf("vimeocdn") > 0) {
+                    var video_id = object
+                        .getAttribute("id")
+                        .replace("player", "")
+                        .split("_")[0];
+                    found.push({
+                        el: object,
+                        url: "http://vimeo.com/" + video_id,
+                    });
+                }
+            }
+            return found;
+        },
+
+        images: function () {
+            var imgs = document.getElementsByTagName("img"),
+                imgs_length = imgs.length,
+                found = [];
+            for (var i = 0; i < imgs_length; i++) {
+                if (imgs[i].offsetWidth < 100 || imgs[i].offsetHeight < 100) {
+                    continue;
+                }
+                found.push(imgs[i]);
+            }
+            return found;
+        },
+    };
+
+    global.MLTSHPStraw = {
+        found: [],
+
+        init: function () {
+            this.initiated = true;
+            this.init_styles();
+            this.find_assets();
+            this.draw_overlays();
+        },
+
+        find_assets: function () {
+            var images = AssetFinder.images(),
+                images_length = images.length,
+                videos = AssetFinder.videos(),
+                videos_length = videos.length,
+                found = [];
+
+            for (var i = 0; i < images_length; i++) {
+                found.push(new Sharedfile("image", images[i].src, images[i]));
+            }
+
+            //for (var i = 0; i < videos_length; i++) {
+            //  found.push(new Sharedfile('video', videos[i].url, videos[i].el));
+            //}
+
+            this.found = found;
+        },
+
+        init_styles: function () {
+            var style =
+                "\
         .mltshp-sf-overlay {font-family: Helvetica,Arial,sans-serif;position: absolute; border: 4px solid #ff0080; text-align: center; cursor: pointer; z-index: 9999999; background-image:url('.'); }\
         .mltshp-sf-overlay-text {display: block; float: left; background-color: #ff0080; font-size: 24px; color: #fff; padding: 10px 20px; text-shadow: 3px 3px 0px #B5005A; \
         -webkit-border-radius: 5px; -moz-border-radius: 5px; border-radius: 5px; \
@@ -245,34 +274,37 @@ java -jar ./tools/compiler.jar --js static/straw/source.js --js_output_file stat
         .mltshp-sf-overlay:hover { border-color: #db008b} \
         .mltshp-sf-overlay:hover .mltshp-sf-overlay-text { background-color: #db008b; } \
       ";
-      var style_el = document.createElement('style');
-      style_el.setAttribute('type', 'text/css');
-      if (style_el.styleSheet !== undefined) {
-        style_el.styleSheet.cssText = style; // IE
-      } else {
-        style_el.innerHTML = style;
-      }
-      global.document.body.appendChild(style_el);
-    },
+            var style_el = document.createElement("style");
+            style_el.setAttribute("type", "text/css");
+            if (style_el.styleSheet !== undefined) {
+                style_el.styleSheet.cssText = style; // IE
+            } else {
+                style_el.innerHTML = style;
+            }
+            global.document.body.appendChild(style_el);
+        },
 
-    draw_overlays: function() {
-      for (var i = 0, length = this.found.length; i < length; i++) {
-        this.found[i].draw_overlay();
-      }
-    },
-  
-    toggle: function() {
-      if (!this.initiated) {
-        this.find_assets();
-        this.draw_overlays();
-      } else {
-        for (var i = 0, found_length = this.found.length; i < found_length; i++) {
-          this.found[i].hide();
-        }
-      }
-      this.initiated = !this.initiated;
-    }
-  };
-  MLTSHPStraw.init();
-  
+        draw_overlays: function () {
+            for (var i = 0, length = this.found.length; i < length; i++) {
+                this.found[i].draw_overlay();
+            }
+        },
+
+        toggle: function () {
+            if (!this.initiated) {
+                this.find_assets();
+                this.draw_overlays();
+            } else {
+                for (
+                    var i = 0, found_length = this.found.length;
+                    i < found_length;
+                    i++
+                ) {
+                    this.found[i].hide();
+                }
+            }
+            this.initiated = !this.initiated;
+        },
+    };
+    MLTSHPStraw.init();
 })(window);


### PR DESCRIPTION
This commit used prettier command to cleanup the formatting of the javascript files.

The config file .prettierignore has been added with already two files to be left out of formatting.

The following command has been used:
prettier  "./**/*.js" --write