### PR TITLE
Removed Dormant Blog and Twitter Links From Footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -165,11 +165,6 @@
 
             <footer class="site-footer">
                 <p>
-                    <a href="https://mltshphq.tumblr.com/" target="_blank" class="link--primary">Read Our Blog</a>
-                    &amp;
-                    <a href="https://twitter.com/mltshphq" target="_blank" class="link--primary">Follow Us On Twitter</a>
-                </p>
-                <p>
                     Are you a developer? <a href="/developers" class="link--primary">Check out our API</a>.
                 </p>
                 <p>


### PR DESCRIPTION
The Tumblr blog is dormant, I assume because there's nothing to share there that we can't directly share here.

And the Twitter profile is dormant, I assume both for the same reason and because most of us left Twitter anyway.

To avoid any misconception that MLTSHP itself is dormant development-wise, let's just remove these links.