### PR TITLE
Stop "Watch on youtube" popup windows from being blocked

### DIFF
--- a/models/sharedfile.py
+++ b/models/sharedfile.py
@@ -276,8 +276,11 @@ class Sharedfile(ModelQueryCache, Model):
 
         # Enable sandbox; only permit scripting (most rich embeds will need this)
         # allow-popups is needed for opening links to original content (ie, YouTube embeds)
+        # allow-popups-to-escape-sandbox frees the popped up window from any
+        # restrictions mltshp decides to enforce.
+        # Related: https://github.com/MLTSHP/mltshp/issues/746
         if 'sandbox=' not in html:
-            extra_attributes += ' sandbox="allow-scripts allow-same-origin allow-popups"'
+            extra_attributes += ' sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"'
 
         # Prevent referrer leaks to third parties
         if 'referrerpolicy=' not in html:


### PR DESCRIPTION
Adds allow-popups-to-escape-sandbox to the sandbox attribute of embedded youtube iframes. This flag allows the new window to open without it being bound by the sandbox flags mltshp chooses to use.

Unit tests pass. Tested on Arc, Chrome, Firefox and Safari on Mac.

Resolves #746