### PR TITLE
Docker compose tweaks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   mltshp:
     image: mltshp/mltshp-web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ services:
         aliases:
           - mltshp.localhost
   fakes3:
-    image: ourtownrentals/fake-s3
+    build:
+      context: fakes3
     entrypoint: fakes3 -r /srv --license ${FAKES3_LICENSE_KEY} -p 8000
     volumes:
       - ./mounts/fakes3:/srv

--- a/fakes3/Dockerfile
+++ b/fakes3/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.7-alpine
+
+RUN mkdir -p /srv
+
+ENV FAKES3_VERSION 2.0.0
+
+RUN gem install --no-document fakes3 -v ${FAKES3_VERSION}
+
+WORKDIR /srv
+
+VOLUME /srv
+EXPOSE 80
+
+ENTRYPOINT ["fakes3", "-r", "/srv", "-p", "80"]

--- a/setup/dev/mysql-conf.d/mltshp.cnf
+++ b/setup/dev/mysql-conf.d/mltshp.cnf
@@ -1,2 +1,2 @@
 [mysqld]
-default_authentication_plugin=mysql_native_password
+mysql-native-password=ON


### PR DESCRIPTION
A handful of small tweaks that made it possible to run the dev environment on my M1 Apple laptop. Basically the fakes3 dependency relies on a docker image that isn't built for arm chips, so this bumps the version to ruby 2.7.