### PR TITLE
Add nsfw category to RSS feed

### DIFF
--- a/templates/shakes/rss.html
+++ b/templates/shakes/rss.html
@@ -38,6 +38,9 @@
 ]]>
 </description>
 <pubDate>{{sf.feed_date()}}</pubDate>
+{% if sf.sourcefile().nsfw %}
+<category>nsfw</category>
+{% end %}
 </item>
 {% end %}
 </channel>


### PR DESCRIPTION
Adds `<category>nsfw</category>` to an RSS item when a file is flagged nsfw.

Related: https://github.com/MLTSHP/best-of-mltshp-bot/issues/2