### PR TITLE
Docker compose tweaks

### DIFF
--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -11,7 +11,7 @@ docker pull mltshp/mltshp-web:build-${BUILDKITE_BUILD_NUMBER}
 docker tag mltshp/mltshp-web:build-${BUILDKITE_BUILD_NUMBER} mltshp/mltshp-web:latest
 
 # launch fakes3/mysql/web app
-docker-compose -f .buildkite/docker-compose.yml up -d
+docker compose -f .buildkite/docker-compose.yml up -d
 
 # let's wait and allow mysql/fakes3 to spin up
 #wait_for localhost 3306
@@ -25,6 +25,6 @@ docker exec -t buildkite_mltshp_1 ./run-tests.sh
 docker exec -t -e BUILDKITE -e BUILDKITE_JOB_ID -e BUILDKITE_BRANCH -e COVERALLS_REPO_TOKEN buildkite_mltshp_1 ./coveralls-report.sh
 
 # tear down containers
-docker-compose -f .buildkite/docker-compose.yml down
+docker compose -f .buildkite/docker-compose.yml down
 
 docker container prune -f

--- a/Makefile
+++ b/Makefile
@@ -6,26 +6,26 @@ init-dev:
 	mkdir -p mounts/mysql mounts/logs mounts/fakes3 mounts/uploaded
 
 run:
-	docker-compose --env-file .env up -d
+	docker compose --env-file .env up -d
 
 stop:
-	docker-compose --env-file .env down
+	docker compose --env-file .env down
 
 build:
 	docker build -t mltshp/mltshp-web:latest .
 
 shell:
-	docker-compose --env-file .env exec mltshp bash
+	docker compose --env-file .env exec mltshp bash
 
 test:
-	docker-compose --env-file .env exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; python test.py $(TEST)"
+	docker compose --env-file .env exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; python test.py $(TEST)"
 
 destroy:
-	docker-compose down
+	docker compose down
 	rm -rf mounts
 
 migrate:
-	docker-compose --env-file .env exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; python migrate.py"
+	docker compose --env-file .env exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; python migrate.py"
 
 mysql:
-	docker-compose --env-file .env exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; mysql -u root --host mysql mltshp"
+	docker compose --env-file .env exec mltshp su ubuntu -c "cd /srv/mltshp.com/mltshp; mysql -u root --host mysql mltshp"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ When you run the application, it launches it into a background process.
 But if you want to watch the realtime logs emitted by each service,
 just use this command:
 
-    $ docker-compose logs -f
+    $ docker compose logs -f
 
 In addition to that, the web app produces some log files that are
 captured under the "mounts/logs" folder of your git repository.
@@ -160,7 +160,7 @@ containers, just use this command:
 If you just wish to rebuild the Docker container, use the Docker
 compose command:
 
-    $ docker-compose down
+    $ docker compose down
 
 Then, run another `make run`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   mltshp:
     image: mltshp/mltshp-web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
         aliases:
           - mltshp.localhost
   fakes3:
-    image: ourtownrentals/fake-s3
+    build:
+      context: fakes3
     entrypoint: fakes3 -r /srv --license ${FAKES3_LICENSE_KEY} -p 8000
     volumes:
       - ./mounts/fakes3:/srv

--- a/fakes3/Dockerfile
+++ b/fakes3/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.7-alpine
+
+RUN mkdir -p /srv
+
+ENV FAKES3_VERSION 2.0.0
+
+RUN gem install --no-document fakes3 -v ${FAKES3_VERSION}
+
+WORKDIR /srv
+
+VOLUME /srv
+EXPOSE 80
+
+ENTRYPOINT ["fakes3", "-r", "/srv", "-p", "80"]

--- a/setup/dev/mysql-conf.d/mltshp.cnf
+++ b/setup/dev/mysql-conf.d/mltshp.cnf
@@ -1,2 +1,2 @@
 [mysqld]
-default_authentication_plugin=mysql_native_password
+mysql-native-password=ON


### PR DESCRIPTION
A handful of small tweaks that made it possible to run the dev environment on my M1 Apple laptop. Basically the fakes3 dependency relies on a docker image that isn't built for arm chips, so this bumps the version to ruby 2.7.

(This is a redux of #755, which got borked in a rebase.)