### PR TITLE
Remap the popular RSS links

### DIFF
--- a/handlers/account.py
+++ b/handlers/account.py
@@ -1063,6 +1063,12 @@ class RSSFeedHandler(BaseHandler):
         if not shake:
             raise tornado.web.HTTPError(404)
         sharedfiles = shake.sharedfiles(per_page=20)
+
+        # If this is the "mltshp" RSS feed, use original files so that links
+        # won't go to the seemingly "unpopular" copy.
+        if user_name == options.best_of_user_name:
+            sharedfiles = map(lambda sf: sf.original(), sharedfiles)
+
         if sharedfiles:
             build_date = sharedfiles[0].feed_date()
 

--- a/handlers/shake.py
+++ b/handlers/shake.py
@@ -491,11 +491,6 @@ class RSSFeedHandler(BaseHandler):
         if sharedfiles:
             build_date = sharedfiles[0].feed_date()
 
-        # If this is the "mltshp" RSS feed, use original files so that links
-        # won't go to the seemingly "unpopular" copy.
-        if shake_name == options.best_of_user_name:
-            sharedfiles = map(lambda sf: sf.original(), sharedfiles)
-
         self.set_header("Content-Type", "application/xml")
         return self.render("shakes/rss.html",
             app_host=options.app_host, shake=shake,


### PR DESCRIPTION
A small "Best of MLTSHP" RSS feed enhancement, links to the original file instead of the version saved by the mltshp user. This is a follow-up to #760.

Re: https://github.com/MLTSHP/mltshp/issues/754