### PR TITLE
Block Meta-ExternalAgent

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -76,3 +76,9 @@ Disallow: /
 
 User-agent: Applebot-Extended
 Disallow: /
+
+# AI Data Scraper
+# https://darkvisitors.com/agents/meta-externalagent
+
+User-agent: Meta-ExternalAgent
+Disallow: /


### PR DESCRIPTION
Added Meta-ExternalAgent, an AI scraper, to robots.txt.