### PR TITLE
Update manifest colors to match page background

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -12,6 +12,6 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff"
+    "theme_color": "#dbfaff",
+    "background_color": "#dbfaff"
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,7 +23,8 @@
     <link rel="icon" type="image/png" href="{{ static_url("images/favicon-16x16.png") }}" sizes="16x16">
     <link rel="manifest" href="{{ static_url("manifest.json") }}">
     <link rel="mask-icon" href="{{ static_url("images/safari-pinned-tab.svg") }}" color="#fc1a9a">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="theme-color" content="#dbfaff" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#13454c" media="(prefers-color-scheme: dark)">
 
     <script type="text/javascript">
     function fallbackImage(source) {


### PR DESCRIPTION
This PR updates the manifest file background and theme color to match the page background color. It also updates the base template's meta theme color attributes to set the appropriate color for light and dark modes.

## Screenshots

(These are screenshots of the base.html file opened directly in Safari. The only thing that matters is you can see the page background extends into the browser chrome in both light and dark mode.

<img width="300" alt="Screenshot 2024-12-29 at 1 19 09 PM" src="https://github.com/user-attachments/assets/01c53c42-7627-4f4b-b785-38df045fb444" />
<img width="300" alt="Screenshot 2024-12-29 at 1 19 16 PM" src="https://github.com/user-attachments/assets/e951e5e3-8205-491a-8c23-ad7ae016469d" />

## Testing

You can test this in MacOS Safari by changing the tab layout to "compact" and toggling your system theme between light and dark.