### PR TITLE
Revised saved links for post permalink page

### DIFF
--- a/handlers/tools.py
+++ b/handlers/tools.py
@@ -370,20 +370,20 @@ class SaveVideoHandler(BaseHandler):
         if 'title' in self.oembed_doc:
             title = self.oembed_doc['title']
 
-        shared_file = Sharedfile(user_id=current_user.id, name=url, content_type='text/html', source_id=source_file.id, title=title, source_url=url)
-        shared_file.save()
+        sharedfile = Sharedfile(user_id=current_user.id, name=url, content_type='text/html', source_id=source_file.id, title=title, source_url=url)
+        sharedfile.save()
 
-        share_key = base36encode(shared_file.id)
-        shared_file.share_key = share_key
-        shared_file.save()
+        share_key = base36encode(sharedfile.id)
+        sharedfile.share_key = share_key
+        sharedfile.save()
 
         user_shake = Shake.get('user_id = %s and type=%s', current_user.id, 'user')
-        shared_file.add_to_shake(self.destination_shake)
+        sharedfile.add_to_shake(self.destination_shake)
 
         if 'description' in self.oembed_doc:
-            shared_file.description = self.oembed_doc['description']
+            sharedfile.description = self.oembed_doc['description']
 
-        self.write({'path' : "/p/%s" % (share_key)})
+        self.write({'path' : sharedfile.post_url(relative=True)})
         self.finish()
 
     @tornado.web.authenticated

--- a/handlers/upload.py
+++ b/handlers/upload.py
@@ -57,7 +57,7 @@ class UploadHandler(BaseHandler):
                     shake_id=shake_id,
                     skip_s3=self.get_argument('skip_s3', None))
                 if sf is not None:
-                    return self.redirect("/p/%s" % (sf.share_key))
+                    return self.redirect(sf.post_url(relative=True))
                 else:
                     raise tornado.web.HTTPError(403)
             else:

--- a/models/sharedfile.py
+++ b/models/sharedfile.py
@@ -306,6 +306,13 @@ class Sharedfile(ModelQueryCache, Model):
 
         return html
 
+    def post_url(self, relative=False):
+        if relative:
+            return '/p/%s' % (self.share_key)
+        else:
+            scheme = (options.use_cdn and "https") or "http"
+            return '%s://%s/p/%s' % (scheme, options.app_host, self.share_key)
+
     def as_json(self, user_context=None):
         """
         If user_context is provided, adds a couple of fields to
@@ -331,7 +338,7 @@ class Sharedfile(ModelQueryCache, Model):
             'description' : self.description,
             'alt_text' : self.alt_text,
             'posted_at' : self.created_at.replace(microsecond=0, tzinfo=None).isoformat() + 'Z',
-            'permalink_page' : '%s://%s/p/%s' % (scheme, options.app_host, self.share_key)
+            'permalink_page' : self.post_url(),
         }
 
         if user_context:

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -818,24 +818,31 @@ $(document).ready(function () {
             render_content: function (response) {
                 var html = "";
                 for (var i = 0, len = response["result"].length; i < len; i++) {
+                    var result = response["result"][i];
+                    var link;
+                    if (result["action"] == "save") {
+                        // for saves, we link to the saved post
+                        link = result["post_url"];
+                    } else {
+                        link = "/user/" + result["user_name"];
+                    }
                     html += '<div class="user-action">';
                     html +=
                         '<a class="icon" href="/user/' +
-                        response["result"][i]["user_name"] +
+                        result["user_name"] +
                         '">';
+                        result["user_name"] +
+                        "</a>";
                     html +=
                         '<img class="avatar--img" src="' +
-                        response["result"][i]["user_profile_image_url"] +
+                        result["user_profile_image_url"] +
                         '" height="20" width="20" alt=""></a>';
-                    html +=
-                        '<a href="/user/' +
-                        response["result"][i]["user_name"] +
-                        '" class="name">' +
-                        response["result"][i]["user_name"] +
+                    html += '<a class="name" href="' + link + '">'
+                        result["user_name"] +
                         "</a>";
                     html +=
                         '<span class="date">' +
-                        response["result"][i]["posted_at_friendly"] +
+                        result["posted_at_friendly"] +
                         "</span>";
                     html += "</div>";
                 }

--- a/tasks/counts.py
+++ b/tasks/counts.py
@@ -33,23 +33,6 @@ def tweet_or_magic(db, sharedfile_id, like_count):
         created_at = utcnow().strftime("%Y-%m-%d %H:%M:%S")
         db.execute("INSERT IGNORE INTO magicfile (sharedfile_id, created_at) VALUES (%s, %s)", sharedfile_id, created_at)
 
-    # The Twitter API is dead.
-    # if like_count == likes_to_tweet and not options.debug:
-    #     title = ''
-    #     if sf['title'] == '' or sf['title'] == None:
-    #         title = sf['name']
-    #     else:
-    #         title = sf['title']
-
-    #     auth = tweepy.OAuthHandler(options.twitter_consumer_key, options.twitter_consumer_secret)
-    #     auth.set_access_token(options.twitter_access_key, options.twitter_access_secret)
-    #     api = tweepy.API(auth)
-    #     via_twitter_account = ""
-    #     twitter_account = db.get("SELECT screen_name from externalservice where user_id = %s and deleted=0", sf['user_id'])
-    #     if twitter_account:
-    #         via_twitter_account = " via @{0}".format(twitter_account['screen_name'])
-    #     api.update_status('https://mltshp.com/p/%s "%s"%s' % (sf['share_key'], title[:90], via_twitter_account))
-
 
 @mltshp_task()
 def calculate_saves(sharedfile_id, **kwargs):

--- a/test/CommentTests.py
+++ b/test/CommentTests.py
@@ -31,7 +31,7 @@ class CommentTests(BaseAsyncTestCase):
 
         That is all.&_xsrf=asdf
         """
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
 
         comments = self.shf.comments()
         self.assertEqual(len(comments), 1)
@@ -39,7 +39,7 @@ class CommentTests(BaseAsyncTestCase):
 
     def test_blank_comment_doesnt_save(self):
         body = ""
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
 
         comments = self.shf.comments()
         self.assertEqual(len(comments), 0)
@@ -48,7 +48,7 @@ class CommentTests(BaseAsyncTestCase):
         #submit a comment to /share_key/save_comment
         body = """
         """
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
 
         comments = self.shf.comments()
         self.assertEqual(len(comments), 0)
@@ -58,33 +58,7 @@ class CommentTests(BaseAsyncTestCase):
         body = """
         This is a comment.
         """
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s' % (self.xsrf)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s' % (self.xsrf)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
 
         comments = self.shf.comments()
         self.assertEqual(len(comments), 0)
-
-    # def test_saving_two_comments_within_24_hrs_restricts(self):
-    #     body = """
-    #         This is a comment.
-    #         """
-
-    #     response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
-
-    #     response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
-
-    #     test_user = User.get('id = 1')
-    #     self.assertEqual(test_user.restricted, 1)
-
-    # def test_saving_two_comments_after_social_does_not_restrict(self):
-
-    #     self.upload_test_file(shake_id=self.admin.shake().id)
-
-    #     body = """
-    #         This is a comment.
-    #         """
-    #     response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
-
-    #     response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape(body), self.xsrf))
-
-   #     test_user = User.get('id = 1')
-   #     self.assertEqual(test_user.restricted, 0)

--- a/test/FileTests.py
+++ b/test/FileTests.py
@@ -154,7 +154,7 @@ class FileViewTests(BaseAsyncTestCase):
         self.assertEqual("1.png", sf.name)
         sf.delete()
 
-        response = self.fetch('/p/%s' % sf.share_key, follow_redirects=False)
+        response = self.fetch(sf.post_url(relative=True), follow_redirects=False)
         self.assertEqual(response.error.code, 404)
 
 

--- a/test/functional/comment_favor_tests.py
+++ b/test/functional/comment_favor_tests.py
@@ -25,7 +25,7 @@ class CommentFavorTests(test.base.BaseAsyncTestCase):
         print(self.comment.user_id)
 
         self.sign_in('admin','asdfasdf')
-        response = self.post_url('/p/%s/comment/%s/like?json=1' % (self.shf.share_key, self.comment.id))
+        response = self.post_url(self.shf.post_url(relative=True) + ('/comment/%s/like?json=1' % (self.comment.id,)))
 
     def test_comment_can_be_liked(self):
         comment_like = models.CommentLike.get('user_id=%s', self.admin.id)
@@ -33,7 +33,7 @@ class CommentFavorTests(test.base.BaseAsyncTestCase):
 
     def test_comment_reliking_reuses_existing_like(self):
         #dislike it
-        response = self.post_url('/p/%s/comment/%s/dislike?json=1' % (self.shf.share_key, self.comment.id))
+        response = self.post_url(self.shf.post_url(relative=True) + ('/comment/%s/dislike?json=1' % (self.comment.id,)))
         comment_like = models.CommentLike.get('user_id=%s', self.admin.id)
         self.assertTrue(comment_like)
 
@@ -41,7 +41,7 @@ class CommentFavorTests(test.base.BaseAsyncTestCase):
         self.assertEqual(comment_like.deleted ,1)
 
         #now it is liked again
-        response = self.post_url('/p/%s/comment/%s/like?json=1' % (self.shf.share_key, self.comment.id))
+        response = self.post_url(self.shf.post_url(relative=True) + ('/comment/%s/like?json=1' % (self.comment.id,)))
 
         comment_like = models.CommentLike.get('user_id=%s', self.admin.id)
         self.assertTrue(comment_like)

--- a/test/functional/conversations_tests.py
+++ b/test/functional/conversations_tests.py
@@ -24,28 +24,27 @@ class ConversationTests(test.base.BaseAsyncTestCase):
         self.shf.save()
 
     def test_creating_a_new_comment_creates_a_conversation(self):
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a comment"), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a comment"), self.xsrf))
 
         conversations = Conversation.all()
         self.assertEqual(len(conversations), 2)
 
     def test_creating_a_new_comment_does_not_create_a_duplicate_conversation(self):
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a comment"), self.xsrf))
-
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a second comment"), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a comment"), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a second comment"), self.xsrf))
         
         conversations = Conversation.all()
         self.assertEqual(len(conversations), 2)
 
     def test_another_user_commenting_will_update_the_files_activity_at(self):
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a comment"), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a comment"), self.xsrf))
 
         time.sleep(1)
         
         sf = Sharedfile.get('id=%s', self.shf.id)
         activity_one = sf.activity_at
 
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a second comment"), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a second comment"), self.xsrf))
         
         sf = Sharedfile.get('id=%s', self.shf.id)
         activity_two = sf.activity_at
@@ -53,9 +52,8 @@ class ConversationTests(test.base.BaseAsyncTestCase):
         self.assertTrue(activity_two > activity_one)
 
     def test_deleting_a_file_will_set_conversation_to_muted(self):
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a comment"), self.xsrf))
-
-        response = self.fetch('/p/%s/comment' % self.shf.share_key, method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a second comment"), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a comment"), self.xsrf))
+        response = self.fetch(self.shf.post_url(relative=True) + '/comment', method='POST', headers={'Cookie':'_xsrf=%s;sid=%s' % (self.xsrf, self.sid)}, body="body=%s&_xsrf=%s" % (url_escape("a second comment"), self.xsrf))
 
         self.shf.delete()
 

--- a/test/functional/image_comment_tests.py
+++ b/test/functional/image_comment_tests.py
@@ -23,7 +23,7 @@ class ImageCommentTests(test.base.BaseAsyncTestCase):
         sharedfile = test.factories.sharedfile(self.admin)
         comment = models.Comment(user_id=self.admin.id, sharedfile_id=sharedfile.id, body="just a comment")
         comment.save()
-        response = self.post_url("/p/%s/comment/%s/delete" % (sharedfile.share_key, comment.id))
+        response = self.post_url(sharedfile.post_url(relative=True) + "/comment/%s/delete" % (comment.id,))
         self.assertEqual(response.code, 403)
         self.assertEqual(comment.id, models.Comment.get("id = %s and deleted = 0", comment.id).id)
         self.assertEqual(None, models.Comment.get("id = %s and deleted = 1", comment.id))
@@ -37,7 +37,7 @@ class ImageCommentTests(test.base.BaseAsyncTestCase):
         comment.save()
         self.sign_in('bob', 'asdfasdf')
         self.assertEqual(None, models.Comment.get("id = %s and deleted = 1", comment.id))
-        response = self.post_url("/p/%s/comment/%s/delete" % (admins_sharedfile.share_key, comment.id))
+        response = self.post_url(admins_sharedfile.post_url(relative=True) + "/comment/%s/delete" % (comment.id,))
         self.assertEqual(comment.id, models.Comment.get("id = %s and deleted = 1", comment.id).id)
     
     def test_delete_anothers_comment_on_own_file(self):
@@ -49,7 +49,7 @@ class ImageCommentTests(test.base.BaseAsyncTestCase):
         comment.save()
         self.sign_in('admin', 'asdfasdf')
         self.assertEqual(None, models.Comment.get("id = %s and deleted = 1", comment.id))
-        response = self.post_url("/p/%s/comment/%s/delete" % (admins_sharedfile.share_key, comment.id))
+        response = self.post_url(admins_sharedfile.post_url(relative=True) + "/comment/%s/delete" % (comment.id,))
         self.assertEqual(comment.id, models.Comment.get("id = %s and deleted = 1", comment.id).id)
 
     def test_can_not_delete_anothers_sharedfile(self):
@@ -62,7 +62,7 @@ class ImageCommentTests(test.base.BaseAsyncTestCase):
         comment.save()
         self.sign_in('tom', 'asdfasdf')
         self.assertEqual(None, models.Comment.get("id = %s and deleted = 1", comment.id))
-        response = self.post_url("/p/%s/comment/%s/delete" % (admins_sharedfile.share_key, comment.id))
+        response = self.post_url(admins_sharedfile.post_url(relative=True) + "/comment/%s/delete" % (comment.id,))
         self.assertEqual(None, models.Comment.get("id = %s and deleted = 1", comment.id))
 
     

--- a/test/functional/image_like_tests.py
+++ b/test/functional/image_like_tests.py
@@ -64,7 +64,7 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         self.assertEqual(None, favorite)
         self.assertEqual(0, sharedfile.like_count)
 
-        response = self.post_url('/p/%s/like?json=1' % sharedfile.share_key)
+        response = self.post_url(sharedfile.post_url(relative=True) + '/like?json=1')
         json_response = json.loads(response.body)
         self.assertEqual(json_response['response'], 'ok')
         self.assertEqual(json_response['count'], 1)
@@ -95,7 +95,7 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         self.assertEqual(1, sharedfile_fetched.like_count)
 
         self.sign_in('joe', 'asdfasdf')
-        response = self.post_url('/p/%s/unlike?json=1' % sharedfile.share_key)
+        response = self.post_url(sharedfile.post_url(relative=True) + '/unlike?json=1')
         json_response = json.loads(response.body)
         self.assertEqual(json_response['response'], 'ok')
         self.assertEqual(json_response['count'], 0)
@@ -113,12 +113,12 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         signed in.  No Favorites should be created.
         """
         sharedfile = self._create_sharedfile(self.admin)
-        response = self.post_url('/p/%s/like?json=1' % sharedfile.share_key)
+        response = self.post_url(sharedfile.post_url(relative=True) + '/like?json=1')
 
         self.assertEqual(response.code, 403)
         favorites = Favorite.all()
         self.assertEqual(len(favorites), 0)
-        response = self.post_url('/p/%s/unlike?json=1' % sharedfile.share_key)
+        response = self.post_url(sharedfile.post_url(relative=True) + '/unlike?json=1')
         self.assertEqual(response.code, 403)
 
     def test_cannot_like_own(self):
@@ -128,7 +128,7 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         """
         sharedfile = self._create_sharedfile(self.admin)
         self.sign_in('admin', 'asdfasdf')
-        response = self.post_url('/p/%s/like?json=1' % sharedfile.share_key)
+        response = self.post_url(sharedfile.post_url(relative=True) + '/like?json=1')
         json_response = json.loads(response.body)
 
         self.assertEqual(response.code, 200)
@@ -144,7 +144,7 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         """
         sharedfile = self._create_sharedfile(self.admin)
         self.sign_in('joe', 'asdfasdf')
-        response = self.post_url('/p/%s/like?json=1' % sharedfile.share_key)
+        response = self.post_url(sharedfile.post_url(relative=True) + '/like?json=1')
 
         notifications = Notification.all()
         self.assertEqual(len(notifications), 1)
@@ -163,7 +163,7 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         bill_sharedfile = joe_sharedfile.save_to_shake(self.bill)
 
         self.sign_in('frank', 'asdfasdf')
-        response = self.post_url('/p/%s/like?json=1' % bill_sharedfile.share_key)
+        response = self.post_url(bill_sharedfile.post_url(relative=True) + '/like?json=1')
 
         self.assertEqual(len(Favorite.all()), 3)
 
@@ -177,9 +177,8 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         bill_sharedfile = joe_sharedfile.save_to_shake(self.bill)
 
         self.sign_in('frank', 'asdfasdf')
-        response = self.post_url('/p/%s/like?json=1' % bill_sharedfile.share_key)
-
-        response = self.post_url('/p/%s/unlike?json=1' % bill_sharedfile.share_key)
+        response = self.post_url(bill_sharedfile.post_url(relative=True) + '/like?json=1')
+        response = self.post_url(bill_sharedfile.post_url(relative=True) + '/unlike?json=1')
 
         un_favorites = Favorite.where('deleted=1')
         self.assertEqual(len(un_favorites),3)
@@ -195,9 +194,9 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         bill_sharedfile = joe_sharedfile.save_to_shake(self.bill)
 
         self.sign_in('frank', 'asdfasdf')
-        response = self.post_url('/p/%s/like?json=1' % bill_sharedfile.share_key)
-        response = self.post_url('/p/%s/unlike?json=1' % bill_sharedfile.share_key)
-        response = self.post_url('/p/%s/like?json=1' % bill_sharedfile.share_key)
+        response = self.post_url(bill_sharedfile.post_url(relative=True) + '/like?json=1')
+        response = self.post_url(bill_sharedfile.post_url(relative=True) + '/unlike?json=1')
+        response = self.post_url(bill_sharedfile.post_url(relative=True) + '/like?json=1')
 
         self.assertEqual(len(Favorite.all()), 3)
 
@@ -210,7 +209,7 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         joe_sharedfile = sharedfile.save_to_shake(self.joe)
 
         self.sign_in('admin', 'asdfasdf')
-        response = self.post_url('/p/%s/like?json=1' % joe_sharedfile.share_key)
+        response = self.post_url(joe_sharedfile.post_url(relative=True) + '/like?json=1')
 
         self.assertEqual(len(Favorite.all()), 1)
 
@@ -225,13 +224,13 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         bill_sharedfile = joe_sharedfile.save_to_shake(self.bill)
 
         self.sign_in('frank', 'asdfasdf')
-        response = self.post_url('/p/%s/like?json=1' % bill_sharedfile.share_key)
+        response = self.post_url(bill_sharedfile.post_url(relative=True) + '/like?json=1')
 
         self.assertEqual(len(Favorite.all()), 3)
         sharedfile.delete()
         joe_sharedfile.delete()
 
-        response = self.post_url('/p/%s/unlike?json=1' % bill_sharedfile.share_key)
+        response = self.post_url(bill_sharedfile.post_url(relative=True) + '/unlike?json=1')
 
         self.assertEqual(len(Favorite.where('deleted = 1')), 3)
 
@@ -248,7 +247,7 @@ class ImageLikeTests(test.base.BaseAsyncTestCase):
         joe_sharedfile.delete()
 
         self.sign_in('frank', 'asdfasdf')
-        response = self.post_url('/p/%s/like?json=1' % bill_sharedfile.share_key)
+        response = self.post_url(bill_sharedfile.post_url(relative=True) + '/like?json=1')
 
         self.assertEqual(len(Favorite.all()), 1)
 

--- a/test/functional/image_nsfw_tests.py
+++ b/test/functional/image_nsfw_tests.py
@@ -23,7 +23,7 @@ class ImageNSFWTests(test.base.BaseAsyncTestCase):
     
     def test_non_logged_in_users_cant_set_nsfw(self):
         sharedfile = test.factories.sharedfile(self.admin)
-        response = self.post_url("/p/%s/nsfw" % sharedfile.share_key)
+        response = self.post_url(sharedfile.post_url(relative=True) + "/nsfw")
         self.assertEqual(403, response.code)
     
     def test_set_nsfw_on_anothers_file(self):
@@ -35,7 +35,7 @@ class ImageNSFWTests(test.base.BaseAsyncTestCase):
         sourcefile = sharedfile.sourcefile()
         self.assertEqual(0, sourcefile.nsfw)
         self.sign_in('bob', 'asdfasdf')
-        response = self.post_url("/p/%s/nsfw" % sharedfile.share_key)
+        response = self.post_url(sharedfile.post_url(relative=True) + "/nsfw")
         self.assertEqual(200, response.code)
         sharedfile = models.Sharedfile.get("id = %s", sharedfile.id)
         sourcefile = sharedfile.sourcefile()

--- a/test/functional/image_save_tests.py
+++ b/test/functional/image_save_tests.py
@@ -46,7 +46,7 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         return sharedfile
 
     def test_non_authenticated_save_returns_403(self):
-        response = self.post_url('/p/%s/save' % self.sharedfile.share_key)
+        response = self.post_url(self.sharedfile.post_url(relative=True) + '/save')
         self.assertEqual(403, response.code)
 
     def test_saving_non_existant_file_returns_404(self):
@@ -64,12 +64,12 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         shared file to start.
         """
         self.sign_in('bob', 'asdfasdf')
-        response = self.post_url('/p/%s/save' % self.sharedfile.share_key)
+        response = self.post_url(self.sharedfile.post_url(relative=True) + '/save')
         self.assertEqual(200, response.code)
         self.assertEqual('/p/2', urlparse(response.effective_url).path)
 
         arguments = {'json' : 1}
-        response = self.post_url('/p/%s/save' % self.sharedfile.share_key, arguments=arguments)
+        response = self.post_url(self.sharedfile.post_url(relative=True) + '/save', arguments=arguments)
         self.assertEqual(200, response.code)
         json_response = json.loads(response.body)
         # because previous save still exists, id should be 3 and count should be 2.
@@ -87,7 +87,7 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         """
         #bob saves admin's original file
         self.sign_in("bob", "asdfasdf")
-        response = self.post_url('/p/%s/save' % self.sharedfile.share_key)
+        response = self.post_url(self.sharedfile.post_url(relative=True) + '/save')
 
         #bob's saves file points to admin's shared file as the parent and admin's shared file as the original id
         bobs_file = Sharedfile.get("share_key= %s and user_id = %s", 2, self.bob.id)
@@ -96,7 +96,7 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
 
         #tom saves bob's file
         self.sign_in("tom", "asdfasdf")
-        response = self.post_url('/p/%s/save' % bobs_file.share_key)
+        response = self.post_url(bobs_file.post_url(relative=True) + '/save')
 
         #tom's saves file points to bob's as the parent and admin's shared file as the original id
         toms_file = Sharedfile.get("share_key=%s and user_id = %s", 3, self.tom.id)
@@ -110,7 +110,7 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         We assume file that gets saved has id of 2.
         """
         self.sign_in("bob", "asdfasdf")
-        self.post_url('/p/%s/save' % self.sharedfile.id)
+        self.post_url(self.sharedfile.post_url(relative=True) + '/save')
         bob_shake = self.bob.shake()
         ssf = Shakesharedfile.where('shake_id = %s', bob_shake.id)
         self.assertEqual(1, len(ssf))
@@ -122,7 +122,7 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         bob's user id.
         """
         self.sign_in("bob", "asdfasdf")
-        self.post_url('/p/%s/save' % self.sharedfile.id)
+        self.post_url(self.sharedfile.post_url(relative=True) + '/save')
         posts = Post.where('user_id = %s', self.bob.id)
         self.assertEqual(1, len(posts))
         self.assertTrue(posts[0].seen)
@@ -140,7 +140,7 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         - type should be save
         """
         self.sign_in("bob", "asdfasdf")
-        self.post_url('/p/%s/save' % self.sharedfile.id)
+        self.post_url(self.sharedfile.post_url(relative=True) + '/save')
         notifications = Notification.all()
         self.assertEqual(len(notifications), 1)
         self.assertEqual(notifications[0].sender_id, self.bob.id)
@@ -155,7 +155,7 @@ class ImageSaveTests(test.base.BaseAsyncTestCase):
         Assume only one file to begin with.
         """
         sid = self.sign_in("bob", "asdfasdf")
-        self.post_url('/p/%s/save' % self.sharedfile.id)
+        self.post_url(self.sharedfile.post_url(relative=True) + '/save')
         sharedfile = Sharedfile.get("share_key = %s and user_id = %s", 2, self.bob.id)
         self.assertEqual(sharedfile.source_url, 'https://www.mltshp.com/?hi')
         self.assertEqual(sharedfile.title, 'the title')

--- a/test/functional/tag_tests.py
+++ b/test/functional/tag_tests.py
@@ -37,7 +37,7 @@ class TagTests(test.base.BaseAsyncTestCase):
     
     def test_create_tag_for_sf_creates_new_tag(self):
         self.sign_in('admin', 'asdfasdf')
-        response = self.post_url('/p/%s/create_tag' % self.sharedfile.share_key, {'tag':'asdf'})
+        response = self.post_url(self.sharedfile.post_url(relative=True) + '/create_tag', {'tag':'asdf'})
         
         all_tags = Tag.all()
         all_tag_shared_files = TagSharedfile.all()
@@ -49,11 +49,8 @@ class TagTests(test.base.BaseAsyncTestCase):
         
     def test_not_signedin_user_cant_creat_tag(self):
         self.sign_in('bob', 'asdfasdf')
-        response = self.post_url('/p/%s/create_tag' % self.sharedfile.share_key, {'tag':'asdf'})
-        
+        response = self.post_url(self.sharedfile.post_url(relative=True) + '/create_tag', {'tag':'asdf'})
 
-        print(self.response.code)
-        
         all_tags = Tag.all()
         all_tag_shared_files = TagSharedfile.all()
         
@@ -62,9 +59,9 @@ class TagTests(test.base.BaseAsyncTestCase):
         
     def test_delete_tag_for_sf(self):
         self.sign_in('admin', 'asdfasdf')
-        self.post_url('/p/%s/create_tag' % self.sharedfile.share_key, {'tag':'asdf'})
+        self.post_url(self.sharedfile.post_url(relative=True) + '/create_tag', {'tag':'asdf'})
         
-        response = self.post_url('/p/%s/delete_tag' % self.sharedfile.share_key, {'tag':'asdf'})
+        response = self.post_url(self.sharedfile.post_url(relative=True) + '/delete_tag', {'tag':'asdf'})
         
         all_tags = Tag.all()
         all_tag_shared_files = TagSharedfile.all()
@@ -76,8 +73,8 @@ class TagTests(test.base.BaseAsyncTestCase):
 
     def test_saving_file_carries_over_tags(self):
         self.sign_in('admin', 'asdfasdf')
-        self.post_url('/p/%s/create_tag' % self.sharedfile.share_key, {'tag':'asdf'})
-        self.post_url('/p/%s/create_tag' % self.sharedfile.share_key, {'tag':'qwer'})
+        self.post_url(self.sharedfile.post_url(relative=True) + '/create_tag', {'tag':'asdf'})
+        self.post_url(self.sharedfile.post_url(relative=True) + '/create_tag', {'tag':'qwer'})
         
         self.sign_in('bob', 'asdfasdf')
         


### PR DESCRIPTION
Links for saved posts now point to the saved post rather than to the user profile.

Added a post_url method to Sharedfile to consolidate code that creates full and relative links to the post page for the shared file (it was duplicated all over the place).

Fixes #801