### PR TITLE
Suppress h1 or h3 tag for empty titles

### DIFF
--- a/templates/uimodules/image.html
+++ b/templates/uimodules/image.html
@@ -31,9 +31,17 @@
             </div>
         {% end %}
         {% if list_view %}
-            <h3>{% if sharedfile.get_title() == "" %}&nbsp;{% else %}{{escape(sharedfile.get_title())}}{% end %}</h3>
+            {% if sharedfile.get_title() == "" and show_attribution_in_title %}
+            <h3>&nbsp;</h3>
+            {% elif sharedfile.get_title() != "" %}
+            <h3>{{escape(sharedfile.get_title())}}</h3>
+            {% end %}
         {% else %}
-            <h1>{% if sharedfile.get_title() == "" %}&nbsp;{% else %}{{escape(sharedfile.get_title())}}{% end %}</h1>
+            {% if sharedfile.get_title() == "" and show_attribution_in_title %}
+            <h1>&nbsp;</h1>
+            {% elif sharedfile.get_title() != "" %}
+            <h1>{{escape(sharedfile.get_title())}}</h1>
+            {% end %}
         {% end %}
         <div class="clear"><!-- --></div>
     {% end %}


### PR DESCRIPTION
Unless in a listing when attribution is shown, otherwise causes layout issue.