### PR TITLE
Changed pretty_date to handle empty input argument

### DIFF
--- a/lib/utilities.py
+++ b/lib/utilities.py
@@ -142,6 +142,9 @@ def pretty_date(time=False):
     """
     Expects a datetime in utc.
     """
+    if not time:
+        return ''
+
     now = utcnow()
     diff = now - time
     second_diff = diff.seconds


### PR DESCRIPTION
Passing an empty argument to pretty_date would cause a fatal error. Though this should probably never occur in practice, we can handle any poor data more robustly.