### PR TITLE
Changed pretty_date to handle empty input argument (#851)

### DIFF
--- a/lib/utilities.py
+++ b/lib/utilities.py
@@ -138,12 +138,15 @@ def generate_digest_from_dictionary(values):
 
 
 # Adapted from http://stackoverflow.com/questions/1551382/python-user-friendly-time-format
-def pretty_date(time=False):
+def pretty_date(pdate):
     """
     Expects a datetime in utc.
     """
+    if pdate is None:
+        return ''
+
     now = utcnow()
-    diff = now - time
+    diff = now - pdate
     second_diff = diff.seconds
     day_diff = diff.days
 

--- a/setup/db-fixtures.sql
+++ b/setup/db-fixtures.sql
@@ -3,8 +3,8 @@
 -- auth_secret for local testing: dummy-secret
 INSERT INTO `user` (`name`, `disable_notifications`, `created_at`) VALUES ('mltshp', 1, now());
 -- password for "admin" is "password" if you're using the local testing auth_secret key
-INSERT INTO `user` (`name`, `hashed_password`, `email`, `full_name`, `email_confirmed`, `is_paid`, `stripe_plan_id`)
-     VALUES ('admin', '9bbdccf408a2420e20fcd157c6315d5f77427c64', 'admin@example.com', 'Site Admin', 1, 1, 'mltshp-double');
+INSERT INTO `user` (`name`, `hashed_password`, `email`, `full_name`, `email_confirmed`, `is_paid`, `stripe_plan_id`, `created_at`)
+     VALUES ('admin', '9bbdccf408a2420e20fcd157c6315d5f77427c64', 'admin@example.com', 'Site Admin', 1, 1, 'mltshp-double', now());
 
 INSERT INTO `shake` (`user_id`, `type`, `name`) VALUES (1, 'user', 'Best of MLTSHP');
 INSERT INTO `shake` (`user_id`, `type`) VALUES (2, 'user');


### PR DESCRIPTION
* Added an empty arg check to pretty_date. Should probably never happen, though was getting an fatal error for what should be a minor data quality issue.

* Based on PR feedback removed default None value (function typically expects one). Renamed function parameter 'time' to avoid any clashes with time std module. Added created_at value to admin user in test database to avoid original issue.