### PR TITLE
Mute commenter's Conversation on a post when their last comment is de…

### DIFF
--- a/models/comment.py
+++ b/models/comment.py
@@ -158,6 +158,13 @@ class Comment(Model):
     def delete(self):
         self.deleted = 1
         self.save()
+        sf = self.sharedfile()
+        if sf and self.user_id != sf.user_id:
+            remaining = Comment.where('user_id = %s and sharedfile_id = %s and deleted = 0', self.user_id, self.sharedfile_id)
+            if not remaining:
+                existing_conversation = conversation.Conversation.get('user_id = %s and sharedfile_id = %s', self.user_id, self.sharedfile_id)
+                if existing_conversation:
+                    existing_conversation.mute()
 
     @classmethod
     def add(self, user=None, sharedfile=None, body=None):

--- a/test/unit/comment_tests.py
+++ b/test/unit/comment_tests.py
@@ -89,6 +89,94 @@ break
         new_conversation = Conversation.where("user_id = %s and sharedfile_id = %s", self.user.id, self.sharedfile.id)
         self.assertEqual(len(new_conversation), 1)
 
+    def test_deleting_only_comment_mutes_commenter_conversation(self):
+        comment = Comment(sharedfile_id=self.sharedfile.id, user_id=self.visitor.id, body="hello")
+        comment.save()
+
+        self.assertEqual(len(Conversation.for_user(self.visitor.id)), 1)
+        self.assertEqual(len(Conversation.for_user(self.user.id)), 1)
+
+        comment.delete()
+
+        self.assertEqual(len(Conversation.for_user(self.visitor.id)), 0)
+        self.assertEqual(len(Conversation.for_user(self.user.id)), 1)
+
+    def test_deleting_only_comment_does_not_mute_file_owner_conversation(self):
+        comment = Comment(sharedfile_id=self.sharedfile.id, user_id=self.visitor.id, body="hello")
+        comment.save()
+
+        comment.delete()
+
+        owner_conversation = Conversation.get("user_id = %s and sharedfile_id = %s", self.user.id, self.sharedfile.id)
+        self.assertTrue(owner_conversation)
+        self.assertEqual(owner_conversation.muted, 0)
+
+    def test_deleting_comments_from_first_mutes_on_last(self):
+        comment1 = Comment(sharedfile_id=self.sharedfile.id, user_id=self.visitor.id, body="first")
+        comment1.save()
+
+        comment2 = Comment(sharedfile_id=self.sharedfile.id, user_id=self.visitor.id, body="second")
+        comment2.save()
+
+        comment1.delete()
+        self.assertEqual(len(Conversation.for_user(self.visitor.id)), 1)
+
+        comment2.delete()
+        self.assertEqual(len(Conversation.for_user(self.visitor.id)), 0)
+
+    def test_deleting_comments_from_last_mutes_on_last(self):
+        comment1 = Comment(sharedfile_id=self.sharedfile.id, user_id=self.visitor.id, body="first")
+        comment1.save()
+
+        comment2 = Comment(sharedfile_id=self.sharedfile.id, user_id=self.visitor.id, body="second")
+        comment2.save()
+
+        comment2.delete()
+        self.assertEqual(len(Conversation.for_user(self.visitor.id)), 1)
+
+        comment1.delete()
+        self.assertEqual(len(Conversation.for_user(self.visitor.id)), 0)
+
+    def test_deleting_comment_does_not_mute_other_commenters_conversation(self):
+        visitor2 = User(name='visitor2', email='visitor2@example.com', verify_email_token='created', email_confirmed=1, is_paid=1)
+        visitor2.save()
+
+        comment1 = Comment(sharedfile_id=self.sharedfile.id, user_id=self.visitor.id, body="first visitor")
+        comment1.save()
+
+        comment2 = Comment(sharedfile_id=self.sharedfile.id, user_id=visitor2.id, body="second visitor")
+        comment2.save()
+
+        comment1.delete()
+
+        self.assertEqual(len(Conversation.for_user(self.visitor.id)), 0)
+        self.assertEqual(len(Conversation.for_user(visitor2.id)), 1)
+
+    def test_recommenting_after_delete_does_not_unmute_conversation(self):
+        comment = Comment(sharedfile_id=self.sharedfile.id, user_id=self.visitor.id, body="hello")
+        comment.save()
+
+        comment.delete()
+        self.assertEqual(len(Conversation.for_user(self.visitor.id)), 0)
+
+        recomment = Comment(sharedfile_id=self.sharedfile.id, user_id=self.visitor.id, body="hello again")
+        recomment.save()
+
+        # re-commenting does not restore a muted conversation
+        self.assertEqual(len(Conversation.for_user(self.visitor.id)), 0)
+
+    def test_file_owner_deleting_visitor_comment_mutes_visitor_conversation(self):
+        comment = Comment(sharedfile_id=self.sharedfile.id, user_id=self.visitor.id, body="hello")
+        comment.save()
+
+        self.assertTrue(comment.can_user_delete(self.user))
+        comment.delete()
+
+        self.assertEqual(len(Conversation.for_user(self.visitor.id)), 0)
+        owner_conversation = Conversation.get("user_id = %s and sharedfile_id = %s", self.user.id, self.sharedfile.id)
+        self.assertTrue(owner_conversation)
+        self.assertEqual(owner_conversation.muted, 0)
+
     def test_comment_chopped_body(self):
         """
         Submits some lengthy comments and predicts their responses.


### PR DESCRIPTION
* When a commenter's only comment on a post is deleted, their Conversation row for that post isn't cleaned up, so the post keeps showing in their Conversations feed indefinitely. Issue #706 

* After deleting a comment, `Comment.delete()` now checks whether the commenter has any remaining comments on that post. If not, their Conversation gets muted. Follows the same pattern as `Sharedfile.delete()` which already mutes conversations when a file is deleted. The file owner's Conversation is left alone regardless.

* Re-commenting after a deletion doesn't unmute. Muted state is shared with the manual mute UI so silently reversing it would override a deliberate user choice.